### PR TITLE
Fixes empty dictionary conversion bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,14 +101,14 @@ test-cov:		## checks test coverage requirements
 		$(TEST_DIR) --cov-fail-under=45 --cov-report term-missing
 
 lint:			## runs the linter against the project
-	pylint --rcfile=.pylintrc $(SRC_DIR)
+	pylint --rcfile=.pylintrc $(SRC_DIR) $(TEST_DIR)
 
 format:			## runs the code auto-formatter
-	isort --profile black --line-length=120 $(SRC_DIR)
-	black --line-length=120 $(SRC_DIR)
+	isort --profile black --line-length=120 $(SRC_DIR) $(TEST_DIR)
+	black --line-length=120 $(SRC_DIR) $(TEST_DIR)
 
 format-docs:	## runs the docstring auto-formatter. Note this requires manually installing `docconvert`
-	docconvert --in-place --config .docconvert.json $(SRC_DIR)
+	docconvert --in-place --config .docconvert.json $(SRC_DIR) $(TEST_DIR)
 
 analyze:		## runs static analyzer on the project
-	mypy --config-file=.mypy.ini --cache-dir=/dev/null $(SRC_DIR)
+	mypy --config-file=.mypy.ini --cache-dir=/dev/null $(SRC_DIR) $(TEST_DIR)

--- a/conda_recipe_manager/parser/recipe_parser.py
+++ b/conda_recipe_manager/parser/recipe_parser.py
@@ -920,7 +920,8 @@ class RecipeParser:
                 test_array.append({"downstream": test_element["downstream"]})
                 del test_element["downstream"]
             # What remains should be the `Command` Test Element type
-            test_array.append(test_element)
+            if test_element:
+                test_array.append(test_element)
             _patch_and_log({"op": "add", "path": new_test_path, "value": test_array})
             _patch_and_log({"op": "remove", "path": test_path})
 

--- a/tests/parser/test_recipe_parser.py
+++ b/tests/parser/test_recipe_parser.py
@@ -125,6 +125,7 @@ def test_loading_obj_in_list() -> None:
         "simple-recipe_multiline_strings.yaml",  # Contains multiple multiline strings, using various operators
         "curl.yaml",  # Complex, multi-output recipe
         "gsm-amzn2-aarch64.yaml",  # Regression test: Contains `- '*'` string that failed to parse
+        "pytest-pep8.yaml",
     ],
 )
 def test_round_trip(file: str) -> None:
@@ -351,6 +352,15 @@ def test_render_to_object_multi_output() -> None:
         ),
         (
             "types-toml.yaml",
+            [],
+            [
+                "Required field missing: /about/license_url",
+            ],
+        ),
+        # Regression test: Contains a `test` section that caused an empty dictionary to be inserted in the conversion
+        # process, causing an index-out-of-range exception.
+        (
+            "pytest-pep8.yaml",
             [],
             [
                 "Required field missing: /about/license_url",
@@ -625,11 +635,11 @@ def test_find_value() -> None:
     assert not parser.find_value("")
     # Values that are not supported for searching
     with pytest.raises(ValueError):
-        parser.find_value(["foo", "bar"])
+        parser.find_value(["foo", "bar"])  # type: ignore[arg-type]
     with pytest.raises(ValueError):
-        parser.find_value(("foo", "bar"))
+        parser.find_value(("foo", "bar"))  # type: ignore[arg-type]
     with pytest.raises(ValueError):
-        parser.find_value({"foo": "bar"})
+        parser.find_value({"foo": "bar"})  # type: ignore[arg-type]
     # Find does not modify the parser
     assert not parser.is_modified()
 
@@ -675,7 +685,7 @@ def test_get_package_paths(file: str, expected: list[str]) -> None:
         ("/foo/bar", "/baz", "/foo/bar/baz"),
     ],
 )
-def test_append_to_path(base: str, ext: str, expected) -> None:
+def test_append_to_path(base: str, ext: str, expected: str) -> None:
     """
     :param base: Base string path
     :param ext: Path to extend the base path with
@@ -898,7 +908,7 @@ def test_contains_selector_at_path(file: str, path: str, expected: bool) -> None
         ("simple-recipe.yaml", "/requirements/empty_field2", "[unix and win]"),
     ],
 )
-def test_get_selector_at_path_exists(file: str, path: str, expected: bool) -> None:
+def test_get_selector_at_path_exists(file: str, path: str, expected: str) -> None:
     """
     Tests cases where a selector exists on a path
     :param file: File to run against
@@ -1083,7 +1093,7 @@ def test_add_comment(file: str, ops: list[tuple[str, str]], expected: str) -> No
         ("simple-recipe.yaml", "/build/number", "    ", ValueError),
     ],
 )
-def test_add_comment_raises(file: str, path: str, comment: str, exception: Exception) -> None:
+def test_add_comment_raises(file: str, path: str, comment: str, exception: BaseException) -> None:
     """
     Tests scenarios where `add_comment()` should raise an exception
     :param file: File to test against
@@ -1092,7 +1102,7 @@ def test_add_comment_raises(file: str, path: str, comment: str, exception: Excep
     :param exception: Exception expected to be raised
     """
     parser = load_recipe(file)
-    with pytest.raises(exception):
+    with pytest.raises(exception):  # type: ignore
         parser.add_comment(path, comment)
 
 

--- a/tests/test_aux_files/new_format_pytest-pep8.yaml
+++ b/tests/test_aux_files/new_format_pytest-pep8.yaml
@@ -1,0 +1,52 @@
+schema_version: 1
+
+context:
+  name: pytest-pep8
+  version: 1.0.6
+  sha256: 032ef7e5fa3ac30f4458c73e05bb67b0f036a8a5cb418a534b3170f89f120318
+
+package:
+  name: ${{ name|lower }}
+  version: ${{ version }}
+
+source:
+  fn: ${{ name }}-${{ version }}.tar.gz
+  url: https://pypi.io/packages/source/${{ name[0] }}/${{ name }}/${{ name }}-${{ version }}.tar.gz
+  sha256: ${{ sha256 }}
+
+build:
+  number: 1
+  noarch: python
+  script: python -m pip install --no-deps --ignore-installed .
+
+requirements:
+  host:
+    - pip
+    - python
+    - setuptools
+  run:
+    - python
+    - pytest-cache
+    - pytest >=2.4.2
+    - pep8 >=1.3
+
+tests:
+  - python:
+      imports:
+        - pytest_pep8
+      pip_check: false
+
+about:
+  license: MIT
+  license_file: LICENSE
+  summary: py.test plugin for efficiently checking PEP8 compliance
+  description: |
+    py.test plugin for efficiently checking PEP8 compliance.
+  homepage: https://bitbucket.org/pytest-dev/pytest-pep8
+  repository: https://bitbucket.org/pytest-dev/pytest-pep8
+  documentation: https://pypi.python.org/pypi/pytest-pep8
+
+extra:
+  recipe-maintainers:
+    - bjodah
+    - nicoddemus

--- a/tests/test_aux_files/pytest-pep8.yaml
+++ b/tests/test_aux_files/pytest-pep8.yaml
@@ -1,0 +1,48 @@
+{% set name = "pytest-pep8" %}
+{% set version = "1.0.6" %}
+{% set sha256 = "032ef7e5fa3ac30f4458c73e05bb67b0f036a8a5cb418a534b3170f89f120318" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  noarch: python
+  number: 1
+  script: python -m pip install --no-deps --ignore-installed .
+
+requirements:
+  host:
+    - pip
+    - python
+    - setuptools
+  run:
+    - python
+    - pytest-cache
+    - pytest >=2.4.2
+    - pep8 >=1.3
+
+test:
+  imports:
+    - pytest_pep8
+
+about:
+  home: https://bitbucket.org/pytest-dev/pytest-pep8
+  license: MIT
+  license_file: LICENSE
+  summary: py.test plugin for efficiently checking PEP8 compliance
+  description: |
+    py.test plugin for efficiently checking PEP8 compliance.
+  doc_url: https://pypi.python.org/pypi/pytest-pep8
+  doc_source_url: https://bitbucket.org/pytest-dev/pytest-pep8/src
+  dev_url: https://bitbucket.org/pytest-dev/pytest-pep8
+
+extra:
+  recipe-maintainers:
+    - bjodah
+    - nicoddemus


### PR DESCRIPTION
- In some scenarios, an empty dictionary could be inserted into a part of the new `tests` section, causing an index-out-of-bounds exception. This PR addresses that issue.
  - Against AnacondaRecipes, this fix increases our "success" conversion metric from 70% to 85%
- Also fixes a few `make` directives that were missing the testing directory. This got missed in upgrading the `Makefile` a few weeks back