### PR TITLE
Starts work on first integration test

### DIFF
--- a/.github/actions/setup-env/action.yaml
+++ b/.github/actions/setup-env/action.yaml
@@ -8,19 +8,6 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
         cache: 'pip'
-    - name: Cache conda env
-      id: cache-conda
-      uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
-      env:
-        cache-name: conda-env-cache
-      with:
-        cache: 'pip'
-        path: '/usr/share/miniconda/envs'
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/environment.yml') }}
-        restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-build-
-          ${{ runner.os }}-
     - name: Create Environment
       shell: bash
       if: ${{ steps.cache-conda.outputs.cache-hit == false }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -109,9 +109,10 @@ jobs:
               ${{ runner.os }}-build-${{ env.cache-name }}-
               ${{ runner.os }}-build-
               ${{ runner.os }}-
-        - name: Build package in rattler-build (experimental)
+        - name: Convert recipes and dry-run rattler-build
           run: |
             source $CONDA/bin/activate
             conda activate conda-recipe-manager
             conda install -y -c conda-forge rattler-build
-            convert tests/test_aux_files/integration/${{ matrix.test-directory }}
+            convert -m 0.80 -o recipe.yaml tests/test_aux_files/integration/${{ matrix.test-directory }}
+            rattler-bulk-build -m 0.30 tests/test_aux_files/integration/${{ matrix.test-directory }} --render-only

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,18 +39,6 @@ jobs:
       runs-on: ubuntu-latest
       steps:
         - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-        - name: Cache conda env
-          id: cache-conda
-          uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
-          env:
-            cache-name: conda-env-cache
-          with:
-            path: '/usr/share/miniconda/envs'
-            key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/environment.yml') }}
-            restore-keys: |
-              ${{ runner.os }}-build-${{ env.cache-name }}-
-              ${{ runner.os }}-build-
-              ${{ runner.os }}-
         - name: Build package in conda build
           run: |
             source $CONDA/bin/activate
@@ -64,18 +52,6 @@ jobs:
         - uses: ./.github/actions/setup-env
           with:
             python-version: "3.11"
-        - name: Cache conda env
-          id: cache-conda
-          uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
-          env:
-            cache-name: conda-env-cache
-          with:
-            path: '/usr/share/miniconda/envs'
-            key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/environment.yml') }}
-            restore-keys: |
-              ${{ runner.os }}-build-${{ env.cache-name }}-
-              ${{ runner.os }}-build-
-              ${{ runner.os }}-
         - name: Build package in rattler-build (experimental)
           run: |
             source $CONDA/bin/activate
@@ -101,5 +77,5 @@ jobs:
             source $CONDA/bin/activate
             conda activate conda-recipe-manager
             conda install -y -c conda-forge rattler-build
-            convert -o recipe.yaml tests/test_aux_files/integration/${{ matrix.test-directory }}
+            convert -m 0.80 -o recipe.yaml tests/test_aux_files/integration/${{ matrix.test-directory }}
             rattler-bulk-build -m 0.30 tests/test_aux_files/integration/${{ matrix.test-directory }} --render-only

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,18 +96,6 @@ jobs:
         - uses: ./.github/actions/setup-env
           with:
             python-version: "3.11"
-        - name: Cache conda env
-          id: cache-conda
-          uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
-          env:
-            cache-name: conda-env-cache
-          with:
-            path: '/usr/share/miniconda/envs'
-            key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/environment.yml') }}
-            restore-keys: |
-              ${{ runner.os }}-build-${{ env.cache-name }}-
-              ${{ runner.os }}-build-
-              ${{ runner.os }}-
         - name: Convert recipes and dry-run rattler-build
           run: |
             source $CONDA/bin/activate

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,7 +84,6 @@ jobs:
             convert -o recipe/recipe.yaml recipe/meta.yaml
             rattler-build build -r recipe/
   ## Integration tests ##
-  # TODO: Add rattler-build to process
   integration-rattler:
       runs-on: ubuntu-latest
       name: Test on ${{ matrix.test-directory }}
@@ -114,5 +113,5 @@ jobs:
             source $CONDA/bin/activate
             conda activate conda-recipe-manager
             conda install -y -c conda-forge rattler-build
-            convert --min-success-rate 0.80 -o recipe.yaml tests/test_aux_files/integration/${{ matrix.test-directory }}
+            convert -o recipe.yaml tests/test_aux_files/integration/${{ matrix.test-directory }}
             rattler-bulk-build -m 0.30 tests/test_aux_files/integration/${{ matrix.test-directory }} --render-only

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,7 +55,7 @@ jobs:
           run: |
             source $CONDA/bin/activate
             conda install -y conda-build
-            conda build .
+            conda build recipe/meta.yaml
   # Eat our own dog food and build this project with rattler-build by converting our existing recipe.
   build-recipe-rattler:
       runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -114,5 +114,5 @@ jobs:
             source $CONDA/bin/activate
             conda activate conda-recipe-manager
             conda install -y -c conda-forge rattler-build
-            convert -m 0.80 -o recipe.yaml tests/test_aux_files/integration/${{ matrix.test-directory }}
+            convert --min-success-rate 0.80 -o recipe.yaml tests/test_aux_files/integration/${{ matrix.test-directory }}
             rattler-bulk-build -m 0.30 tests/test_aux_files/integration/${{ matrix.test-directory }} --render-only

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,3 +83,35 @@ jobs:
             conda install -y -c conda-forge rattler-build
             convert -o recipe/recipe.yaml recipe/meta.yaml
             rattler-build build -r recipe/
+  ## Integration tests ##
+  # TODO: Add rattler-build to process
+  integration-rattler:
+      runs-on: ubuntu-latest
+      name: Test on ${{ matrix.test-directory }}
+      strategy:
+        matrix:
+          test-directory:
+            - anaconda_recipes
+      steps:
+        - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        - uses: ./.github/actions/setup-env
+          with:
+            python-version: "3.11"
+        - name: Cache conda env
+          id: cache-conda
+          uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
+          env:
+            cache-name: conda-env-cache
+          with:
+            path: '/usr/share/miniconda/envs'
+            key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/environment.yml') }}
+            restore-keys: |
+              ${{ runner.os }}-build-${{ env.cache-name }}-
+              ${{ runner.os }}-build-
+              ${{ runner.os }}-
+        - name: Build package in rattler-build (experimental)
+          run: |
+            source $CONDA/bin/activate
+            conda activate conda-recipe-manager
+            conda install -y -c conda-forge rattler-build
+            convert tests/test_aux_files/integration/${{ matrix.test-directory }}

--- a/conda_recipe_manager/commands/convert.py
+++ b/conda_recipe_manager/commands/convert.py
@@ -23,6 +23,9 @@ from conda_recipe_manager.parser.types import MessageCategory, MessageTable
 OLD_FORMAT_RECIPE_FILE_NAME: Final[str] = "meta.yaml"
 # Required file name for the recipe, specified in CEP-13
 NEW_FORMAT_RECIPE_FILE_NAME: Final[str] = "recipe.yaml"
+# When performing a bulk operation, overall "success" is indicated by the % of recipe files that were converted
+# "successfully"
+BULK_SUCCESS_PASS_THRESHOLD: Final[float] = 0.80
 
 
 class ExitCode(IntEnum):
@@ -33,6 +36,8 @@ class ExitCode(IntEnum):
     SUCCESS = 0
     CLICK_ERROR = 1  # Controlled by the `click` library
     CLICK_USAGE = 2  # Controlled by the `click` library
+    # In bulk operation mode, this indicates that the % success threshold was not met
+    MISSED_SUCCESS_THRESHOLD = 42
     # Errors are roughly ordered by increasing severity
     RENDER_WARNINGS = 100
     RENDER_ERRORS = 101
@@ -265,6 +270,7 @@ def convert(path: Path, output: Optional[Path]) -> None:  # pylint: disable=rede
 
     # Self-check metric. This should be the same as the other calculated success metric.
     num_theoretical_recipe_success: Final[int] = total_recipes - (len(recipes_with_except) + len(recipes_with_errors))
+    percent_recipe_success: Final[float] = round(num_recipe_success / total_recipes, 2)
 
     stats = {
         "total_recipe_files": total_recipes,
@@ -279,7 +285,7 @@ def convert(path: Path, output: Optional[Path]) -> None:  # pylint: disable=rede
         "percent_recipe_exceptions": round(len(recipes_with_except) / total_recipes, 2),
         "percent_recipe_errors": round(len(recipes_with_errors) / total_recipes, 2),
         "percent_recipe_warnings": round(len(recipes_with_warnings) / total_recipes, 2),
-        "percent_recipe_success": round(num_recipe_success / total_recipes, 2),
+        "percent_recipe_success": percent_recipe_success,
         "percent_recipe_theoretical_success": round(num_theoretical_recipe_success / total_recipes, 2),
         "timings": {
             "total_exec_time": round(total_time, 2),
@@ -299,4 +305,6 @@ def convert(path: Path, output: Optional[Path]) -> None:  # pylint: disable=rede
     }
 
     print_out(json.dumps(final_output, indent=2))
-    sys.exit(ExitCode.SUCCESS)
+    sys.exit(
+        ExitCode.SUCCESS if percent_recipe_success > BULK_SUCCESS_PASS_THRESHOLD else ExitCode.MISSED_SUCCESS_THRESHOLD
+    )

--- a/conda_recipe_manager/commands/rattler_bulk_build.py
+++ b/conda_recipe_manager/commands/rattler_bulk_build.py
@@ -1,0 +1,162 @@
+"""
+File:           rattler_bulk_build.py
+Description:    CLI tool that performs a bulk build operation for rattler-build.
+"""
+from __future__ import annotations
+
+import json
+import multiprocessing as mp
+import re
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from enum import IntEnum
+from pathlib import Path
+from typing import Final, cast
+
+import click
+
+# Required file name for the recipe, specified in CEP-13
+NEW_FORMAT_RECIPE_FILE_NAME: Final[str] = "recipe.yaml"
+# When performing a bulk operation, overall "success" is indicated by the % of recipe files that were built
+# "successfully"
+DEFAULT_BULK_SUCCESS_PASS_THRESHOLD: Final[float] = 0.80
+RATTLER_ERROR_REGEX = re.compile(r"Error:\s+.*")
+
+
+class ExitCode(IntEnum):
+    """
+    Error codes to return upon script completion
+    """
+
+    SUCCESS = 0
+    NO_FILES_FOUND = 1
+    # In bulk operation mode, this indicates that the % success threshold was not met
+    MISSED_SUCCESS_THRESHOLD = 42
+
+
+@dataclass
+class BuildResult:
+    """
+    Struct that contains the results, metadata, errors, etc of building a single recipe file.
+    """
+
+    code: ExitCode
+    errors: list[str]
+
+
+def print_err(*args, **kwargs) -> None:  # type: ignore
+    """
+    Convenience wrapper that prints to STDERR
+    """
+    print(*args, file=sys.stderr, **kwargs)  # type: ignore
+
+
+def build_recipe(file: Path, path: Path, args: list[str]) -> tuple[str, BuildResult]:
+    """
+    Helper function that performs the build operation for parallelizable execution. Logs rattler-build failures to
+    STDERR.
+    :param file: Recipe file to build
+    :param path: Path argument provided by the user
+    :param args: List of arguments to provide whole-sale to rattler-build
+    :returns: Tuple containing the key/value pairing that tracks the result of the build operation
+    """
+    cmd: list[str] = ["rattler-build", "build", "-r", str(file)]
+    cmd.extend(args)
+    output: Final[subprocess.CompletedProcess[str]] = subprocess.run(
+        " ".join(cmd),
+        encoding="utf-8",
+        capture_output=True,
+        shell=True,
+        check=False,
+    )
+
+    return str(file.relative_to(path)), BuildResult(
+        code=ExitCode(output.returncode),
+        errors=cast(list[str], RATTLER_ERROR_REGEX.findall(output.stderr)),
+    )
+
+
+@click.command(
+    short_help="Given a directory, performs a bulk rattler-build operation. Assumes rattler-build is installed.",
+    context_settings=cast(
+        dict[str, bool],
+        {
+            "ignore_unknown_options": True,
+            "allow_extra_args": True,
+        },
+    ),
+)
+@click.argument("path", type=click.Path(exists=True, path_type=Path))  # type: ignore[misc]
+@click.option(
+    "--min-success-rate",
+    "-m",
+    type=click.FloatRange(0, 1),
+    default=DEFAULT_BULK_SUCCESS_PASS_THRESHOLD,
+    help="Sets a minimum passing success rate for bulk operations.",
+)
+@click.pass_context
+def rattler_bulk_build(ctx: click.Context, path: Path, min_success_rate: float) -> None:
+    """
+    Given a directory of feedstock repositories, performs multiple recipe builds using rattler-build.
+    All unknown options and arguments for this script are passed directly to `rattler-build build`.
+    NOTE:
+        - The build command is run as `rattler-build build -r <recipe.yaml> <ARGS>`
+        - rattler-build errors are dumped to STDERR
+    """
+    start_time: Final[float] = time.time()
+    files: Final[list[Path]] = []
+    for file_path in path.rglob(NEW_FORMAT_RECIPE_FILE_NAME):
+        files.append(file_path)
+
+    if not files:
+        print_err(f"No `recipe.yaml` files found in: {path}")
+        sys.exit(ExitCode.NO_FILES_FOUND)
+
+    # Process recipes in parallel
+    thread_pool_size: Final[int] = mp.cpu_count()
+    with mp.Pool(thread_pool_size) as pool:
+        results = dict(pool.starmap(build_recipe, [(file, path, ctx.args) for file in files]))  # type: ignore[misc]
+
+    # Gather statistics
+    total_recipes: Final[int] = len(files)
+    total_processed: Final[int] = len(results)
+    total_errors = 0
+    total_success = 0
+    recipes_with_errors: list[str] = []
+    error_histogram: dict[str, int] = {}
+    for file, build_result in results.items():
+        if build_result.code == ExitCode.SUCCESS:
+            total_success += 1
+        else:
+            total_errors += 1
+            recipes_with_errors.append(file)
+        if build_result.errors:
+            for error in build_result.errors:
+                if error not in error_histogram:
+                    error_histogram[error] = 0
+                error_histogram[error] += 1
+    percent_success: Final[float] = round(total_success / total_recipes, 2)
+
+    total_time: Final[float] = time.time() - start_time
+    stats = {
+        "total_recipe_files": total_recipes,
+        "total_recipes_processed": total_processed,
+        "total_errors": total_errors,
+        "percent_errors": round(total_errors / total_recipes, 2),
+        "percent_success": percent_success,
+        "timings": {
+            "total_exec_time": round(total_time, 2),
+            "avg_recipe_time": round(total_time / total_recipes, 2),
+            "thread_pool_size": thread_pool_size,
+        },
+    }
+    final_output = {
+        "recipes_with_build_error_code": recipes_with_errors,
+        "error_histogram": error_histogram,
+        "stats": stats,
+    }
+
+    print(json.dumps(final_output, indent=2))
+    sys.exit(ExitCode.SUCCESS if percent_success >= min_success_rate else ExitCode.MISSED_SUCCESS_THRESHOLD)

--- a/conda_recipe_manager/parser/recipe_parser.py
+++ b/conda_recipe_manager/parser/recipe_parser.py
@@ -759,12 +759,14 @@ class RecipeParser:
 
                 # For now, if a selector lands on a boolean value, use a ternary statement. Otherwise use the
                 # conditional logic.
-                # TODO `skip` is special and now can be a list of boolean expressions.
                 patch: JsonPatchType = {
                     "op": "replace",
                     "path": selector_path,
                     "value": "${{ true if " + bool_expression + " }}",
                 }
+                # `skip` is special and needs to be a list of boolean expressions.
+                if selector_path.endswith("/build/skip"):
+                    patch["value"] = [bool_expression]
                 if not isinstance(info.node.value, bool):
                     # CEP-13 states that ONLY list members may use the `if/then/else` blocks
                     if not info.node.list_member_flag:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ conda_build = ["conda-build"]
 
 [project.scripts]
 convert = "conda_recipe_manager.commands.convert:convert"
+rattler-bulk-build = "conda_recipe_manager.commands.rattler_bulk_build:rattler_bulk_build"
 
 [project.urls]
 "Homepage" = "https://github.com/anaconda/conda-recipe-manager"

--- a/tests/test_aux_files/integration/anaconda_recipes/types-pyyaml-feedstock/recipe/meta.yaml
+++ b/tests/test_aux_files/integration/anaconda_recipes/types-pyyaml-feedstock/recipe/meta.yaml
@@ -1,0 +1,56 @@
+{% set name = "types-PyYAML" %}
+{% set version = "6.0.12.12" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/types-PyYAML-{{ version }}.tar.gz
+  sha256: 334373d392fde0fdf95af5c3f1661885fa10c52167b14593eb856289e1855062
+
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
+  skip: true  # [py<36]
+
+requirements:
+  host:
+    - pip
+    - python
+    - wheel
+    - setuptools
+  run:
+    - python
+
+
+test:
+  imports:
+    - types
+  requires:
+    - pip
+  commands:
+    - pip check
+    - test -f $SP_DIR/yaml-stubs/__init__.pyi  # [unix]
+
+
+about:
+  home: https://github.com/python/typeshed
+  summary: Typing stubs for PyYAML
+  license: Apache-2.0 AND MIT
+  license_file: LICENSE
+  license_family: OTHER
+  description: |
+    This is a PEP 561 type stub package for the PyYaml package.
+    It can be used by type-checking tools like mypy, pyright, pytype,
+    PyCharm, etc. to check code that uses PyYaml.
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://pyyaml.org/wiki/PyYAMLDocumentation
+
+
+extra:
+  recipe-maintainers:
+    - fhoehle
+    - conda-forge/mypy

--- a/tests/test_aux_files/integration/anaconda_recipes/types-toml-feedstock/recipe/meta.yaml
+++ b/tests/test_aux_files/integration/anaconda_recipes/types-toml-feedstock/recipe/meta.yaml
@@ -1,0 +1,53 @@
+{% set name = "types-toml" %}
+{% set version = "0.10.8.6" %}
+
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/types-toml-{{ version }}.tar.gz
+  sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
+
+build:
+  number: 0
+  skip: true  # [py<37]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - setuptools
+    - wheel
+    - pip
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - types
+  requires:
+    - pip
+  commands:
+    - pip check
+    - test -f $SP_DIR/toml-stubs/__init__.pyi  # [unix]
+
+
+about:
+  home: https://github.com/python/typeshed
+  summary: Typing stubs for toml
+  description: |
+    This is a PEP 561 type stub package for the toml package.
+    It can be used by type-checking tools like mypy, pyright,
+    pytype, PyCharm, etc. to check code that uses toml.
+  license: Apache-2.0 AND MIT
+  license_file: LICENSE
+  license_family: OTHER
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://pypi.org/project/types-toml/
+
+extra:
+  recipe-maintainers:
+    - fhoehle
+    - conda-forge/mypy

--- a/tests/test_aux_files/new_format_huggingface_hub.yaml
+++ b/tests/test_aux_files/new_format_huggingface_hub.yaml
@@ -14,7 +14,8 @@ source:
 
 build:
   number: 0
-  skip: ${{ true if py<37 }}
+  skip:
+    - py<37
   script: ${{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   python:
     entry_points:

--- a/tests/test_aux_files/new_format_simple-recipe.yaml
+++ b/tests/test_aux_files/new_format_simple-recipe.yaml
@@ -11,7 +11,8 @@ package:
 
 build:
   number: 0
-  skip: ${{ true if py<37 }}
+  skip:
+    - py<37
   is_true: true
 
 requirements:

--- a/tests/test_aux_files/new_format_types-toml.yaml
+++ b/tests/test_aux_files/new_format_types-toml.yaml
@@ -14,7 +14,8 @@ source:
 
 build:
   number: 0
-  skip: ${{ true if py<37 }}
+  skip:
+    - py<37
   script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:


### PR DESCRIPTION
This first-pass of an integration test runs a bulk conversion operation against a few recipe files. In the future, I anticipate adding many more recipe files from various sources, to get a clear picture at how the conversion process is going.

In essence, the new integration test...
- Installs the project
- Converts all recipes in the integration test folder (1 instance per category/directory of files)
- Takes the converted recipes and performs a dry-run build using rattler-build of each recipe that has been converted.
  - This does not exclude files that had errors in the conversion process. If a `recipe.yaml` exists in the test directory, it will undergo a dry-run build.
- The conversion and dry-run-build phases must pass a minimum success threshold in order to "pass"

Some notes:
- Success in the conversion phase is measured by meeting a threshold % of "successful" conversions
- Success in the rattler-build phase is measured by how many builds return 0
