### PR TITLE
Refactor: Commands execute under `conda-recipe-manager` namespace

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Syntax for this file at https://help.github.com/articles/about-codeowners/
 
-*       @conda/builds-tools
+*       @conda-incubator/builds-tools
 *       @schuylermartin45

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,3 @@
 # Syntax for this file at https://help.github.com/articles/about-codeowners/
 
-*       @conda-incubator/builds-tools
-*       @schuylermartin45
+*   @conda-incubator/builds-tools @schuylermartin45

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Syntax for this file at https://help.github.com/articles/about-codeowners/
+
+*       @conda/builds-tools
+*       @schuylermartin45

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # Syntax for this file at https://help.github.com/articles/about-codeowners/
 
-*   @conda-incubator/builds-tools @schuylermartin45
+*   @conda-incubator/builds-tools

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,7 +57,7 @@ jobs:
             source $CONDA/bin/activate
             conda activate conda-recipe-manager
             conda install -y -c conda-forge rattler-build
-            convert -o recipe/recipe.yaml recipe/meta.yaml
+            conda-recipe-manager convert -o recipe/recipe.yaml recipe/meta.yaml
             mkdir -p ../temp
             rattler-build build -r recipe/ --output-dir=../temp
   ## Integration tests ##
@@ -78,5 +78,5 @@ jobs:
             source $CONDA/bin/activate
             conda activate conda-recipe-manager
             conda install -y -c conda-forge rattler-build
-            convert -m 0.80 -o recipe.yaml tests/test_aux_files/integration/${{ matrix.test-directory }}
-            rattler-bulk-build -m 0.30 tests/test_aux_files/integration/${{ matrix.test-directory }} --render-only
+            conda-recipe-manager convert -m 0.80 -o recipe.yaml tests/test_aux_files/integration/${{ matrix.test-directory }}
+            conda-recipe-manager rattler-bulk-build -m 0.30 tests/test_aux_files/integration/${{ matrix.test-directory }} --render-only

--- a/conda_recipe_manager/commands/conda_recipe_manager.py
+++ b/conda_recipe_manager/commands/conda_recipe_manager.py
@@ -1,0 +1,27 @@
+"""
+File:           conda_recipe_manager.py
+Description:    Base CLI for all `conda-recipe-manager` commands
+"""
+
+from __future__ import annotations
+
+import click
+
+from conda_recipe_manager.commands.convert import convert
+from conda_recipe_manager.commands.rattler_bulk_build import rattler_bulk_build
+
+
+@click.group()
+def conda_recipe_manager() -> None:
+    """
+    Command line interface for conda recipe management commands.
+    """
+    pass
+
+
+conda_recipe_manager.add_command(convert)
+conda_recipe_manager.add_command(rattler_bulk_build)
+
+
+if __name__ == "__main__":
+    conda_recipe_manager()

--- a/conda_recipe_manager/commands/convert.py
+++ b/conda_recipe_manager/commands/convert.py
@@ -17,6 +17,7 @@ from typing import Final, Optional
 
 import click
 
+from conda_recipe_manager.commands.utils.print import print_err, print_messages, print_out
 from conda_recipe_manager.parser.recipe_parser_convert import RecipeParserConvert
 from conda_recipe_manager.parser.types import MessageCategory, MessageTable
 
@@ -59,31 +60,6 @@ class ConversionResult:
     msg_tbl: MessageTable
     # Extracted out of the path for bulk operations
     project_name: str
-
-
-def print_out(*args, **kwargs) -> None:  # type: ignore
-    """
-    Convenience wrapper that prints to STDOUT
-    """
-    print(*args, file=sys.stdout, **kwargs)  # type: ignore
-
-
-def print_err(*args, **kwargs) -> None:  # type: ignore
-    """
-    Convenience wrapper that prints to STDERR
-    """
-    print(*args, file=sys.stderr, **kwargs)  # type: ignore
-
-
-def print_messages(category: MessageCategory, msg_tbl: MessageTable) -> None:
-    """
-    Convenience function for dumping a series of messages of a certain category
-    :param category: Category of messages to print
-    :param msg_tbl: `MessageTable` instance containing the messages to print
-    """
-    msgs: Final[list[str]] = msg_tbl.get_messages(category)
-    for msg in msgs:
-        print_err(f"[{category.upper()}]: {msg}")
 
 
 def convert_file(file_path: Path, output: Optional[Path], print_output: bool) -> ConversionResult:

--- a/conda_recipe_manager/commands/rattler_bulk_build.py
+++ b/conda_recipe_manager/commands/rattler_bulk_build.py
@@ -18,6 +18,8 @@ from typing import Final, cast
 
 import click
 
+from conda_recipe_manager.commands.utils.print import print_err
+
 # Required file name for the recipe, specified in CEP-13
 NEW_FORMAT_RECIPE_FILE_NAME: Final[str] = "recipe.yaml"
 # When performing a bulk operation, overall "success" is indicated by the % of recipe files that were built
@@ -45,13 +47,6 @@ class BuildResult:
 
     code: ExitCode
     errors: list[str]
-
-
-def print_err(*args, **kwargs) -> None:  # type: ignore
-    """
-    Convenience wrapper that prints to STDERR
-    """
-    print(*args, file=sys.stderr, **kwargs)  # type: ignore
 
 
 def build_recipe(file: Path, path: Path, args: list[str]) -> tuple[str, BuildResult]:

--- a/conda_recipe_manager/commands/utils/print.py
+++ b/conda_recipe_manager/commands/utils/print.py
@@ -1,0 +1,36 @@
+"""
+File:           print.py
+Description:    Provides print utility functions
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Final
+
+from conda_recipe_manager.parser.types import MessageCategory, MessageTable
+
+
+def print_out(*args, **kwargs) -> None:  # type: ignore
+    """
+    Convenience wrapper that prints to STDOUT
+    """
+    print(*args, file=sys.stdout, **kwargs)  # type: ignore
+
+
+def print_err(*args, **kwargs) -> None:  # type: ignore
+    """
+    Convenience wrapper that prints to STDERR
+    """
+    print(*args, file=sys.stderr, **kwargs)  # type: ignore
+
+
+def print_messages(category: MessageCategory, msg_tbl: MessageTable) -> None:
+    """
+    Convenience function for dumping a series of messages of a certain category
+    :param category: Category of messages to print
+    :param msg_tbl: `MessageTable` instance containing the messages to print
+    """
+    msgs: Final[list[str]] = msg_tbl.get_messages(category)
+    for msg in msgs:
+        print_err(f"[{category.upper()}]: {msg}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,8 @@ dev = ["pytest"]
 conda_build = ["conda-build"]
 
 [project.scripts]
-convert = "conda_recipe_manager.commands.convert:convert"
-rattler-bulk-build = "conda_recipe_manager.commands.rattler_bulk_build:rattler_bulk_build"
+conda-recipe-manager = "conda_recipe_manager.commands.conda_recipe_manager:conda_recipe_manager"
+crm = "conda_recipe_manager.commands.conda_recipe_manager:conda_recipe_manager"
 
 [project.urls]
 "Homepage" = "https://github.com/anaconda/conda-recipe-manager"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ build:
   noarch: python
   script: pip install . --no-deps --no-build-isolation -vv
   entry_points:
-    - convert = conda_recipe_manager.commands.convert:convert
+    - conda-recipe-manager = conda_recipe_manager.commands.conda_recipe_manager:conda_recipe_manager
 
 requirements:
   host:

--- a/tests/commands/test_conda_recipe_manager.py
+++ b/tests/commands/test_conda_recipe_manager.py
@@ -1,0 +1,23 @@
+"""
+File:           test_conda_recipe_manager.py
+Description:    Tests the base `conda-recipe-manager` CLI
+"""
+
+from click.testing import CliRunner
+
+from conda_recipe_manager.commands.conda_recipe_manager import conda_recipe_manager
+
+
+def test_usage() -> None:
+    """
+    Smoke test that ensures rendering of the help menu
+    """
+    runner = CliRunner()
+    # No commands are provided
+    result = runner.invoke(conda_recipe_manager, [])
+    assert result.exit_code == 0
+    assert result.output.startswith("Usage:")
+    # Help is specified
+    result = runner.invoke(conda_recipe_manager, ["--help"])
+    assert result.exit_code == 0
+    assert result.output.startswith("Usage:")

--- a/tests/commands/test_convert.py
+++ b/tests/commands/test_convert.py
@@ -10,7 +10,7 @@ from conda_recipe_manager.commands.convert import convert
 
 def test_usage() -> None:
     """
-    Ensure failure to provide a sub-command results in rendering the help menu
+    Smoke test that ensures rendering of the help menu
     """
     runner = CliRunner()
     # No commands are provided

--- a/tests/commands/test_rattler_bulk_build.py
+++ b/tests/commands/test_rattler_bulk_build.py
@@ -1,0 +1,23 @@
+"""
+File:           test_rattler_bulk_build.py
+Description:    Tests the `rattler-bulk-build` CLI
+"""
+
+from click.testing import CliRunner
+
+from conda_recipe_manager.commands.rattler_bulk_build import rattler_bulk_build
+
+
+def test_usage() -> None:
+    """
+    Smoke test that ensures rendering of the help menu
+    """
+    runner = CliRunner()
+    # No commands are provided
+    result = runner.invoke(rattler_bulk_build, [])
+    assert result.exit_code != 0
+    assert result.output.startswith("Usage:")
+    # Help is specified
+    result = runner.invoke(rattler_bulk_build, ["--help"])
+    assert result.exit_code == 0
+    assert result.output.startswith("Usage:")

--- a/tests/parser/test_recipe_parser.py
+++ b/tests/parser/test_recipe_parser.py
@@ -17,9 +17,9 @@ from tests.file_loading import TEST_FILES_PATH, load_file, load_recipe
 
 # Long multi-line description string found in the `simple-recipe.yaml` test file
 SIMPLE_DESCRIPTION: Final[str] = (
-    "This is a PEP '561 type stub package for the toml package."
-    "\nIt can be used by type-checking tools like mypy, pyright,"
-    "\npytype, PyCharm, etc. to check code that uses toml."
+    "This is a PEP '561 type stub package for the toml package.\n"
+    "It can be used by type-checking tools like mypy, pyright,\n"
+    "pytype, PyCharm, etc. to check code that uses toml."
 )
 
 # Multiline string used to validate interpretation of the various multiline variations YAML allows

--- a/tests/parser/test_recipe_parser.py
+++ b/tests/parser/test_recipe_parser.py
@@ -16,9 +16,11 @@ from conda_recipe_manager.types import JsonType
 from tests.file_loading import TEST_FILES_PATH, load_file, load_recipe
 
 # Long multi-line description string found in the `simple-recipe.yaml` test file
-SIMPLE_DESCRIPTION: Final[
-    str
-] = "This is a PEP '561 type stub package for the toml package.\nIt can be used by type-checking tools like mypy, pyright,\npytype, PyCharm, etc. to check code that uses toml."  # pylint: disable=line-too-long
+SIMPLE_DESCRIPTION: Final[str] = (
+    "This is a PEP '561 type stub package for the toml package."
+    "\nIt can be used by type-checking tools like mypy, pyright,"
+    "\npytype, PyCharm, etc. to check code that uses toml."
+)
 
 # Multiline string used to validate interpretation of the various multiline variations YAML allows
 QUICK_FOX_PIPE: Final[str] = "The quick brown\n{{fox}}\n\njumped over the lazy dog\n"


### PR DESCRIPTION
- Addresses feedback from https://github.com/conda-incubator/conda-recipe-manager/issues/19
  - `convert` and `rattler-bulk-build` now execute under `conda-recipe-manager`
      - Alternatively, use `crm` for short
  - For example, instead of `convert recipe/meta.yaml` you now use:
    `conda-recipe-manager convert recipe/meta.yaml`
- Refactors and adds missing CLI smoke tests
- Breaks-out duplicated work in the scripts into a new `commands.utils.print`
  module
- `black` got an update that changes spacing between `from __future__ ...` and
  the file comment that precedes it