### PR TITLE
Enables McCabe code-complexity checking and refactors the worst offenders

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
   - id: black
     args: [--line-length=120]
 - repo: https://github.com/PyCQA/pylint
-  rev: v3.0.3
+  rev: v3.1.0
   hooks:
   - id: pylint
     args: ["--rcfile=.pylintrc"]

--- a/.pylintrc
+++ b/.pylintrc
@@ -24,8 +24,8 @@ persistent=no
 
 # List of plugins (as comma separated values of python modules names) to load,
 # usually to register additional checkers.
-# conda Delta: Added docparams extension
-load-plugins=pylint.extensions.docparams
+# conda Delta: Added docparams and mccabe extensions
+load-plugins=pylint.extensions.docparams, pylint.extensions.mccabe
 
 # Use multiple processes to speed up Pylint.
 # conda Delta: bumped from 4 to 8 jobs

--- a/conda_recipe_manager/commands/utils/print.py
+++ b/conda_recipe_manager/commands/utils/print.py
@@ -11,18 +11,22 @@ from typing import Final
 from conda_recipe_manager.parser.types import MessageCategory, MessageTable
 
 
-def print_out(*args, **kwargs) -> None:  # type: ignore
+def print_out(*args, print_enabled: bool = True, **kwargs) -> None:  # type: ignore
     """
     Convenience wrapper that prints to STDOUT
+    :param print_enabled: (Optional) Flag to enable printing. Enabled by default.
     """
-    print(*args, file=sys.stdout, **kwargs)  # type: ignore
+    if print_enabled:
+        print(*args, file=sys.stdout, **kwargs)  # type: ignore
 
 
-def print_err(*args, **kwargs) -> None:  # type: ignore
+def print_err(*args, print_enabled: bool = True, **kwargs) -> None:  # type: ignore
     """
     Convenience wrapper that prints to STDERR
+    :param print_enable: (Optional) Flag to enable printing. Enabled by default.
     """
-    print(*args, file=sys.stderr, **kwargs)  # type: ignore
+    if print_enabled:
+        print(*args, file=sys.stderr, **kwargs)  # type: ignore
 
 
 def print_messages(category: MessageCategory, msg_tbl: MessageTable) -> None:

--- a/conda_recipe_manager/parser/recipe_parser.py
+++ b/conda_recipe_manager/parser/recipe_parser.py
@@ -270,6 +270,7 @@ class RecipeParser:
         traverse_all(self._root, _collect_selectors)
 
     def __init__(self, content: str):
+        # pylint: disable=too-complex
         """
         Constructs a RecipeParser instance.
         :param content: conda-build formatted recipe file, as a single text string.
@@ -455,6 +456,7 @@ class RecipeParser:
 
     @staticmethod
     def _render_tree(node: Node, depth: int, lines: list[str], parent: Optional[Node] = None) -> None:
+        # pylint: disable=too-complex
         """
         Recursive helper function that traverses the parse tree to generate a file.
         :param node: Current node in the tree
@@ -572,6 +574,7 @@ class RecipeParser:
 
     @no_type_check
     def _render_object_tree(self, node: Node, replace_variables: bool, data: JsonType) -> None:
+        # pylint: disable=too-complex
         """
         Recursive helper function that traverses the parse tree to generate a Pythonic data object.
         :param node: Current node in the tree

--- a/conda_recipe_manager/parser/recipe_parser.py
+++ b/conda_recipe_manager/parser/recipe_parser.py
@@ -271,6 +271,7 @@ class RecipeParser:
 
     def __init__(self, content: str):
         # pylint: disable=too-complex
+        # TODO Refactor and simplify ^
         """
         Constructs a RecipeParser instance.
         :param content: conda-build formatted recipe file, as a single text string.
@@ -457,6 +458,7 @@ class RecipeParser:
     @staticmethod
     def _render_tree(node: Node, depth: int, lines: list[str], parent: Optional[Node] = None) -> None:
         # pylint: disable=too-complex
+        # TODO Refactor and simplify ^
         """
         Recursive helper function that traverses the parse tree to generate a file.
         :param node: Current node in the tree
@@ -575,6 +577,7 @@ class RecipeParser:
     @no_type_check
     def _render_object_tree(self, node: Node, replace_variables: bool, data: JsonType) -> None:
         # pylint: disable=too-complex
+        # TODO Refactor and simplify ^
         """
         Recursive helper function that traverses the parse tree to generate a Pythonic data object.
         :param node: Current node in the tree

--- a/conda_recipe_manager/parser/recipe_parser_convert.py
+++ b/conda_recipe_manager/parser/recipe_parser_convert.py
@@ -42,6 +42,8 @@ class RecipeParserConvert(RecipeParser):
         self._new_recipe: RecipeParser = RecipeParser(self.render())
         self._msg_tbl = MessageTable()
 
+    ## Patch utility functions ##
+
     def _patch_and_log(self, patch: JsonPatchType) -> None:
         """
         Convenience function that logs failed patches to the message table.
@@ -95,31 +97,18 @@ class RecipeParserConvert(RecipeParser):
             node.value = rename
         node.children.sort(key=_comparison)
 
-    def render_to_new_recipe_format(self) -> tuple[str, MessageTable]:
-        # pylint: disable=protected-access
+    ## Upgrade functions ##
+
+    def _upgrade_jinja_to_context_obj(self) -> None:
         """
-        Takes the current recipe representation and renders it to the new format WITHOUT modifying the current recipe
-        state.
-
-        The "new" format is defined in the following CEPs:
-          - https://github.com/conda-incubator/ceps/blob/main/cep-13.md
-          - https://github.com/conda-incubator/ceps/blob/main/cep-14.md
-
-        (As of writing there is no official name other than "the new recipe format")
+        Upgrades the old proprietary JINJA templating usage to the new YAML-parsable `context` object and `$`-escaped
+        JINJA substitutions.
         """
-        # Approach: In the event that we want to expand support later, this function should be implemented in terms
-        # of a `RecipeParser` tree. This will make it easier to build an upgrade-path, if we so choose to pursue one.
-
-        # Log the original comments
-        old_comments: Final[dict[str, str]] = self._new_recipe.get_comments_table()
-
-        ## JINJA -> `context` object ##
-
         # Convert the JINJA variable table to a `context` section. Empty tables still add the `context` section for
         # future developers' convenience.
         self._patch_and_log({"op": "add", "path": "/context", "value": None})
         # Filter-out any value not covered in the new format
-        for name, value in self._new_recipe._vars_tbl.items():
+        for name, value in self._new_recipe._vars_tbl.items():  # pylint: disable=protected-access
             if not isinstance(value, (str, int, float, bool)):
                 self._msg_tbl.add_message(MessageCategory.WARNING, f"The variable `{name}` is an unsupported type.")
                 continue
@@ -141,8 +130,11 @@ class RecipeParserConvert(RecipeParser):
             value = value.replace("{{", "${{")
             self._patch_and_log({"op": "replace", "path": path, "value": value})
 
-        ## Convert selectors into ternary statements or `if` blocks ##
-        for selector, instances in self._new_recipe._selector_tbl.items():
+    def _upgrade_selectors_to_conditionals(self) -> None:
+        """
+        Upgrades the proprietary comment-based selector syntax to equivalent conditional logic statements.
+        """
+        for selector, instances in self._new_recipe._selector_tbl.items():  # pylint: disable=protected-access
             for info in instances:
                 # Selectors can be applied to the parent node if they appear on the same line. We'll ignore these when
                 # building replacements.
@@ -184,14 +176,11 @@ class RecipeParserConvert(RecipeParser):
                 self._patch_and_log(patch)
                 self._new_recipe.remove_selector(selector_path)
 
-        # Cached copy of all of the "outputs" in a recipe. This is useful for easily handling multi and single output
-        # recipes in 1 loop construct.
-        base_package_paths: Final[list[str]] = self._new_recipe.get_package_paths()
-
-        # TODO Fix: comments are not preserved with patch operations (add a flag to `patch()`?)
-
-        ## `build` section changes and validation ##
-
+    def _upgrade_build_section(self, base_package_paths: list[str]) -> None:
+        """
+        Upgrades/converts the `about` section(s) of a recipe file.
+        :param base_package_paths: Set of base paths to process that could contain this section.
+        """
         for base_path in base_package_paths:
             # Move `run_exports` and `ignore_run_exports` from `build` to `requirements`
 
@@ -225,8 +214,10 @@ class RecipeParserConvert(RecipeParser):
             # Canonically sort this section
             self._sort_subtree_keys(build_path, V1_BUILD_SECTION_KEY_SORT_ORDER)
 
-        ## `about` section changes and validation ##
-
+    def _upgrade_about_section(self) -> None:
+        """
+        Upgrades/converts the `about` section of a recipe file.
+        """
         # Warn if "required" fields are missing
         about_required: Final[list[str]] = [
             "summary",
@@ -265,8 +256,12 @@ class RecipeParserConvert(RecipeParser):
             if self._new_recipe.contains_value(path):
                 self._patch_and_log({"op": "remove", "path": path})
 
-        ## `test` section changes and upgrades ##
-
+    def _upgrade_test_section(self, base_package_paths: list[str]) -> None:
+        # pylint: disable=too-complex
+        """
+        Upgrades/converts the `test` section(s) of a recipe file.
+        :param base_package_paths: Set of base paths to process that could contain this section.
+        """
         # NOTE: For now, we assume that the existing test section comprises of a single test entity. Developers will
         # have to use their best judgement to manually break-up the test into multiple tests as they see fit.
         for base_path in base_package_paths:
@@ -341,27 +336,68 @@ class RecipeParserConvert(RecipeParser):
             self._patch_and_log({"op": "add", "path": new_test_path, "value": test_array})
             self._patch_and_log({"op": "remove", "path": test_path})
 
-        ## Upgrade the multi-output section(s) ##
+    def _upgrade_multi_output(self, base_package_paths: list[str]) -> None:
+        """
+        Upgrades/converts sections pertaining to multi-output recipes.
+        :param base_package_paths: Set of base paths to process that could contain this section.
+        """
+        if not self._new_recipe.contains_value("/outputs"):
+            return
+
         # TODO Complete
-        if self._new_recipe.contains_value("/outputs"):
-            # On the top-level, `package` -> `recipe`
-            self._patch_move_base_path(ROOT_NODE_VALUE, "/package", "/recipe")
+        # On the top-level, `package` -> `recipe`
+        self._patch_move_base_path(ROOT_NODE_VALUE, "/package", "/recipe")
 
-            for output_path in base_package_paths:
-                if output_path == ROOT_NODE_VALUE:
-                    continue
+        for output_path in base_package_paths:
+            if output_path == ROOT_NODE_VALUE:
+                continue
 
-                # Move `name` and `version` under `package`
-                if self._new_recipe.contains_value(
-                    RecipeParser.append_to_path(output_path, "/name")
-                ) or self._new_recipe.contains_value(RecipeParser.append_to_path(output_path, "/version")):
-                    self._patch_add_missing_path(output_path, "/package")
-                self._patch_move_base_path(output_path, "/name", "/package/name")
-                self._patch_move_base_path(output_path, "/version", "/package/version")
+            # Move `name` and `version` under `package`
+            if self._new_recipe.contains_value(
+                RecipeParser.append_to_path(output_path, "/name")
+            ) or self._new_recipe.contains_value(RecipeParser.append_to_path(output_path, "/version")):
+                self._patch_add_missing_path(output_path, "/package")
+            self._patch_move_base_path(output_path, "/name", "/package/name")
+            self._patch_move_base_path(output_path, "/version", "/package/version")
 
-                # Not all the top-level keys are found in each output section, but all the output section keys are
-                # found at the top-level. So for consistency, we sort on that ordering.
-                self._sort_subtree_keys(output_path, TOP_LEVEL_KEY_SORT_ORDER)
+            # Not all the top-level keys are found in each output section, but all the output section keys are
+            # found at the top-level. So for consistency, we sort on that ordering.
+            self._sort_subtree_keys(output_path, TOP_LEVEL_KEY_SORT_ORDER)
+
+    def render_to_new_recipe_format(self) -> tuple[str, MessageTable]:
+        """
+        Takes the current recipe representation and renders it to the new format WITHOUT modifying the current recipe
+        state.
+
+        The "new" format is defined in the following CEPs:
+          - https://github.com/conda-incubator/ceps/blob/main/cep-13.md
+          - https://github.com/conda-incubator/ceps/blob/main/cep-14.md
+
+        (As of writing there is no official name other than "the new recipe format")
+        """
+        # Approach: In the event that we want to expand support later, this function should be implemented in terms
+        # of a `RecipeParser` tree. This will make it easier to build an upgrade-path, if we so choose to pursue one.
+
+        # Log the original comments
+        old_comments: Final[dict[str, str]] = self._new_recipe.get_comments_table()
+
+        # JINJA templates -> `context` object
+        self._upgrade_jinja_to_context_obj()
+
+        ## Convert selectors into ternary statements or `if` blocks ##
+        self._upgrade_selectors_to_conditionals()
+
+        # Cached copy of all of the "outputs" in a recipe. This is useful for easily handling multi and single output
+        # recipes in 1 loop construct.
+        base_package_paths: Final[list[str]] = self._new_recipe.get_package_paths()
+
+        # TODO Fix: comments are not preserved with patch operations (add a flag to `patch()`?)
+
+        # Upgrade common sections found in a recipe
+        self._upgrade_build_section(base_package_paths)
+        self._upgrade_about_section()
+        self._upgrade_test_section(base_package_paths)
+        self._upgrade_multi_output(base_package_paths)
 
         ## Final clean-up ##
 
@@ -380,7 +416,7 @@ class RecipeParserConvert(RecipeParser):
         #                risk of screwing up critical list indices and ordering.
 
         # Hack: Wipe the existing table so the JINJA `set` statements don't render the final form
-        self._new_recipe._vars_tbl = {}
+        self._new_recipe._vars_tbl = {}  # pylint: disable=protected-access
 
         # Sort the top-level keys to a "canonical" ordering. This should make previous patch operations look more
         # "sensible" to a human reader.

--- a/conda_recipe_manager/parser/recipe_parser_convert.py
+++ b/conda_recipe_manager/parser/recipe_parser_convert.py
@@ -258,6 +258,7 @@ class RecipeParserConvert(RecipeParser):
 
     def _upgrade_test_section(self, base_package_paths: list[str]) -> None:
         # pylint: disable=too-complex
+        # TODO Refactor and simplify ^
         """
         Upgrades/converts the `test` section(s) of a recipe file.
         :param base_package_paths: Set of base paths to process that could contain this section.

--- a/environment.yaml
+++ b/environment.yaml
@@ -11,7 +11,7 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-xdist
-  - pylint
+  - conda-forge::pylint ==3.1.0  # Match version with .pre-commit-config.yaml
   - pip
   - click >=8.1.7
   - conda


### PR DESCRIPTION
Enables McCabe code complexity checks via `pylint`. Also:

- Aligns the versions of `pylint` used by `pre-commit` and the `conda-recipe-manager` environment
- Refactors `convert.py` to comply with the new setting
- Suppresses the `too-complex` rule for `recipe_parser.py`. There are 3 functions out of compliance that are crucial to parsing and rendering recipes. Most of these are recursive and contain many "return-early" paradigms.
  - IMO, these are not worth addressing at this time. We have bigger fish to fry.
- Breaks `recipe_parser_convert.py` into many pieces. Each "upgrade" process is now its own function. Only one of these has a complexity score of 11 and that linting error is suppressed for now.