### PR TITLE
Fixes `pip_check` inclusion issue

### DIFF
--- a/tests/test_aux_files/new_format_curl.yaml
+++ b/tests/test_aux_files/new_format_curl.yaml
@@ -95,8 +95,6 @@ outputs:
           then: if exist %LIBRARY_LIB%\libcurl_a.lib exit 1
         - if: win
           then: if not exist %LIBRARY_BIN%\libcurl.dll exit 1
-      python:
-        pip-check: false
   - package:
       name: libcurl-static
     requirements:
@@ -122,8 +120,6 @@ outputs:
           then: test -f $PREFIX/lib/libcurl.a
         - if: win
           then: if not exist %LIBRARY_LIB%\libcurl_a.lib exit 1
-      python:
-        pip-check: false
   - package:
       name: curl
     files:
@@ -151,8 +147,6 @@ outputs:
         - curl https://raw.githubusercontent.com/conda-forge/curl-feedstock/master/LICENSE.txt
         - if: win
           then: if not exist %LIBRARY_BIN%\curl.exe exit 1
-      python:
-        pip-check: false
 
 about:
   license: curl

--- a/tests/test_aux_files/new_format_google-cloud-cpp.yaml
+++ b/tests/test_aux_files/new_format_google-cloud-cpp.yaml
@@ -77,8 +77,6 @@ outputs:
         - libgoogle-cloud-speech
         - libgoogle-cloud-talent
     tests:
-      - python:
-          pip_check: false
       - script:
         - test -f $PREFIX/lib/libgoogle_cloud_cpp_kms.${{ version }}.dylib
         - test -f $PREFIX/lib/libgoogle_cloud_cpp_kms.so.${{ version }}
@@ -143,8 +141,6 @@ outputs:
       run_exports:
         - ${{ pin_subpackage("libgoogle-cloud-all", max_pin="x.x") }}
     tests:
-      - python:
-          pip_check: false
       - files:
           recipe:
             - run_test_feature.sh
@@ -182,8 +178,6 @@ outputs:
       run_exports:
         - ${{ pin_subpackage("libgoogle-cloud-all", max_pin="x.x") }}
     tests:
-      - python:
-          pip_check: false
       - script:
           - echo no test needed
 

--- a/tests/test_aux_files/new_format_multi-output.yaml
+++ b/tests/test_aux_files/new_format_multi-output.yaml
@@ -10,8 +10,6 @@ outputs:
       run_exports:
         - bar
     tests:
-      - python:
-          pip_check: false
       - script:
           - if: unix
             then: test -f ${PREFIX}/lib/libdb${SHLIB_EXT}
@@ -30,7 +28,5 @@ outputs:
       run:
         - foo
     tests:
-      - python:
-          pip_check: false
       - script:
           - db_archive -m hello


### PR DESCRIPTION
- Addresses Issue #23
- `pip_check` is now only added to "python recipes"
  - A "python recipe" is a recipe where `python` is listed as a `run` dependency. If it is included for a non-python recipe, `rattler-build` will error-out for not conforming to the schema.
- Updates unit tests.