### PR TITLE
Fixes Issue #25

### DIFF
--- a/conda_recipe_manager/parser/recipe_parser.py
+++ b/conda_recipe_manager/parser/recipe_parser.py
@@ -259,13 +259,12 @@ class RecipeParser:
             if not node.comment:
                 return
             match = Regex.SELECTOR.search(node.comment)
-            if match:
-                selector = match.group(0)
-                selector_info = SelectorInfo(node, list(path))
-                if selector not in self._selector_tbl:
-                    self._selector_tbl[selector] = [selector_info]
-                else:
-                    self._selector_tbl[selector].append(selector_info)
+            if not match:
+                return
+            selector = match.group(0)
+            selector_info = SelectorInfo(node, list(path))
+            self._selector_tbl.setdefault(selector, [])
+            self._selector_tbl[selector].append(selector_info)
 
         traverse_all(self._root, _collect_selectors)
 

--- a/conda_recipe_manager/parser/recipe_parser_convert.py
+++ b/conda_recipe_manager/parser/recipe_parser_convert.py
@@ -395,11 +395,12 @@ class RecipeParserConvert(RecipeParser):
         # Log the original comments
         old_comments: Final[dict[str, str]] = self._new_recipe.get_comments_table()
 
+        # Convert selectors into ternary statements or `if` blocks. We process selectors first so that there is no
+        # chance of selector comments getting accidentally wiped by patch or other operations.
+        self._upgrade_selectors_to_conditionals()
+
         # JINJA templates -> `context` object
         self._upgrade_jinja_to_context_obj()
-
-        ## Convert selectors into ternary statements or `if` blocks ##
-        self._upgrade_selectors_to_conditionals()
 
         # Cached copy of all of the "outputs" in a recipe. This is useful for easily handling multi and single output
         # recipes in 1 loop construct.

--- a/tests/parser/test_recipe_parser_convert.py
+++ b/tests/parser/test_recipe_parser_convert.py
@@ -18,6 +18,7 @@ from tests.file_loading import TEST_FILES_PATH, load_file, load_recipe_convert
             "simple-recipe.yaml",
             [],
             [
+                "A non-list item had a selector at: /package/name",
                 "A non-list item had a selector at: /requirements/empty_field2",
                 "Required field missing: /about/license_file",
                 "Required field missing: /about/license_url",

--- a/tests/test_aux_files/new_format_google-cloud-cpp.yaml
+++ b/tests/test_aux_files/new_format_google-cloud-cpp.yaml
@@ -78,8 +78,10 @@ outputs:
         - libgoogle-cloud-talent
     tests:
       - script:
-        - test -f $PREFIX/lib/libgoogle_cloud_cpp_kms.${{ version }}.dylib
-        - test -f $PREFIX/lib/libgoogle_cloud_cpp_kms.so.${{ version }}
+          - if: osx
+            then: test -f $PREFIX/lib/libgoogle_cloud_cpp_kms.${{ version }}.dylib
+          - if: linux
+            then: test -f $PREFIX/lib/libgoogle_cloud_cpp_kms.so.${{ version }}
           - if: win
             then: if exist %LIBRARY_LIB%\google_cloud_cpp_kms.lib exit 1
           - if: unix


### PR DESCRIPTION
- Fixes an issue described in #25 that left some selectors unconditionalized.
- To address this, selectors are converted first before any other operations are performed. By doing this phase first, we ensure that the selector table points to the correct paths and no selectors are accidentally wiped by patch operations.
- Makes some minor refactoring for the sake of code clean-up.
- This does not add any new regression tests, BUT does fix existing tests to ensure that the regression is caught. The mistake was previously missed when adding those tests.