### PR TITLE
Stats aggregation script

### DIFF
--- a/conda_recipe_manager/commands/convert.py
+++ b/conda_recipe_manager/commands/convert.py
@@ -307,6 +307,10 @@ def convert(
     }
 
     final_output = {
+        "info": {
+            "command_name": "convert",
+            "directory": Path(path).name,
+        },
         "exception_histogram": except_histogram,
         "error_histogram": errors_histogram,
         "warnings_histogram": warnings_histogram,

--- a/conda_recipe_manager/commands/rattler_bulk_build.py
+++ b/conda_recipe_manager/commands/rattler_bulk_build.py
@@ -160,6 +160,10 @@ def rattler_bulk_build(ctx: click.Context, path: Path, min_success_rate: float, 
         },
     }
     final_output = {
+        "info": {
+            "command_name": "rattler-bulk-build",
+            "directory": Path(path).name,
+        },
         "error_histogram": error_histogram,
         "stats": stats,
     }

--- a/conda_recipe_manager/commands/rattler_bulk_build.py
+++ b/conda_recipe_manager/commands/rattler_bulk_build.py
@@ -165,7 +165,7 @@ def rattler_bulk_build(ctx: click.Context, path: Path, min_success_rate: float, 
             "directory": Path(path).name,
         },
         "error_histogram": error_histogram,
-        "stats": stats,
+        "statistics": stats,
     }
     if not truncate:
         final_output["recipes_with_build_error_code"] = recipes_with_errors

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -6,6 +6,19 @@ This directory contains 1-off development scripts related to this project.
 
 They should not be packaged to be run by a user/consumer of this project.
 
+# parse_ci_output.py
+
+Utility script that reads the directory of log files provided by GitHub's CI infrastructure. The script then
+parses-out the JSON output from the integration tests and aggregates the statistics into an accumulative
+JSON structure.
+
+## Usage:
+```sh
+usage: parse_ci_output.py [-h] [-v] dir
+```
+Where `-v` enables the `verbose` report, including the fully-parsed JSON found in all of the logs and
+`dir` is the directory containing the log files from GitHub.
+
 # randomly_select_recipes.py
 
 Given a list of feedstock repositories owned by a GitHub organization, randomly select `NUM_RECIPES` number of recipe

--- a/scripts/parse_ci_output.py
+++ b/scripts/parse_ci_output.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""
+File:           parse_ci_output.py
+Description:    Given a directory of CI logs, parse and organize the JSON output for easier consumption.
+                This is a quick and dirty script, not meant to be maintained with the usual standard of quality.
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Final, cast, no_type_check
+
+# Adapted from: https://stackoverflow.com/questions/3143070/regex-to-match-an-iso-8601-datetime-string
+ISO_8601_REGEX: Final[re.Pattern[str]] = re.compile(r"\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+Z\s")
+
+# Regex used to find a single JSON blob
+JSON_OBJ_REGEX: Final[re.Pattern[str]] = re.compile(r"\n\{\n.*\n\}\n", re.MULTILINE | re.DOTALL)
+
+# Basic JSON type to shut the static analyzer up for our purposes. Allows the script to be run independently without
+# referencing the better JSON type defined in this project.
+BasicJsonType = dict[str, dict[str, int | str] | str]
+
+
+@no_type_check
+def generate_summary(convert_results: list[BasicJsonType], dry_run_results: list[BasicJsonType]) -> BasicJsonType:
+    """
+    Given the list of parsed JSON blobs of interest from the log files, summarize the results.
+
+    NOTE: Type-checking has been disabled for this function given that the statistics we will track may change
+    frequently and we don't want this helper script to become a maintenance headache. The access of JSON values is on
+    output that we have direct control over.
+
+    :param convert_results: List of parsed JSON for conversion results
+    :param dry_run_results: List of parsed JSON for dry-run results
+    :returns: Summary JSON object to display in the final results.
+    """
+    test_counts: dict[str, int] = {}
+
+    # Aggregate conversion stats
+    for result in convert_results:
+        test = Path(result["info"]["directory"]).name
+        test_counts.setdefault(test, 0)
+        test_counts[test] += 1
+
+    # Aggregate dry-run stats
+    for result in dry_run_results:
+        test = Path(result["info"]["directory"]).name
+        test_counts.setdefault(test, 0)
+        test_counts[test] += 1
+
+    return {
+        "test_counts": dict(sorted(test_counts.items())),
+        "stages": {
+            "recipe_conversion": {},
+            "rattler_dry_run": {},
+        },
+    }
+
+
+def main() -> None:
+    """
+    Main execution point of the script
+    """
+    parser = argparse.ArgumentParser(
+        description="Extracts JSON results from CI operations from a directory of CI log files"
+    )
+    parser.add_argument("dir", type=Path, help="Directory that contains log files to parse.")  # type: ignore[misc]
+    args = parser.parse_args()
+
+    log_dir: Final[Path] = Path(cast(str, args.dir))
+
+    # Separate test results into their own lists
+    convert_results: list[BasicJsonType] = []
+    dry_run_results: list[BasicJsonType] = []
+
+    # Parse-out all the recognized JSON blobs found in the log files.
+    for file in log_dir.iterdir():
+        if file.is_dir() or file.name == ".DS_Store":
+            continue
+        content = file.read_text(encoding="utf-8")
+        # Strip out all the timestamps
+        lines = ISO_8601_REGEX.sub("", content).splitlines()
+
+        start_idx = 0
+        for i, line in enumerate(lines):
+            if line == "{":
+                start_idx = i
+            if line == "}":
+                # Log the range of lines that failed to be recognized, if need be.
+                log_range = f"{file}:{start_idx+1}-{i+1}"
+                try:
+                    data = cast(BasicJsonType, json.loads("\n".join(lines[start_idx : i + 1])))
+                    # Filter-out unrecognized JSON blobs in the logs
+                    if "info" not in data or "command_name" not in data["info"]:
+                        print(f"Could not recognize JSON object from {log_range}", file=sys.stderr)
+                        continue
+                    if data["info"]["command_name"] == "convert":  # type: ignore[index]
+                        convert_results.append(data)
+                    else:
+                        dry_run_results.append(data)
+                except json.JSONDecodeError:
+                    start_idx = 0
+                    print(f"Could not parse lines from {log_range}", file=sys.stderr)
+                    continue
+
+    # Aggregate the final results, putting the summary information at the top, followed by the raw results from the
+    # log files.
+    final_results = {
+        "summary": cast(BasicJsonType, generate_summary(convert_results, dry_run_results)),
+        # TODO re-enable
+        # "raw_conversion_results": convert_results,
+        # "raw_dry_run_results": dry_run_results,
+    }
+
+    print(json.dumps(final_results, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a quick and dirty script for parsing-out JSON results from the CI integration test scripts

To use, download all the log files from the CI run of interest and point the script at that directory. It will parse-out all the JSON objects and aggregate the statistics into a final report, including a summary of the entire run.

Here are the current results:
```json
{
  "summary": {
    "test_counts": {
      "anaconda_recipes_01": 2,
      "bioconda_recipes_01": 2,
      "bioconda_recipes_02": 2,
      "bioconda_recipes_03": 2,
      "bioconda_recipes_04": 2,
      "conda_forge_recipes_01": 2
    },
    "stages": {
      "recipe_conversion": {
        "total_recipe_files": 11336,
        "total_recipes_processed": 11336,
        "total_errors": 2,
        "total_warnings": 17806,
        "num_recipe_exceptions": 2993,
        "num_recipe_errors": 2,
        "num_recipe_warnings": 8342,
        "num_recipe_success": 8341,
        "num_theoretical_recipe_success": 8341,
        "percent_recipe_exceptions": 0.22,
        "percent_recipe_errors": 0.0,
        "percent_recipe_warnings": 0.78,
        "percent_recipe_success": 0.78,
        "percent_recipe_theoretical_success": 0.78
      },
      "rattler_dry_run": {
        "total_recipe_files": 8343,
        "total_recipes_processed": 8343,
        "total_errors": 5573,
        "percent_errors": 0.57,
        "percent_success": 0.43
      }
    }
  }
}
```