### PR TITLE
Fixes Issue #18 by adding a new conversion pre-processor

### DIFF
--- a/conda_recipe_manager/parser/_types.py
+++ b/conda_recipe_manager/parser/_types.py
@@ -91,7 +91,12 @@ class Regex:
     # Pattern to detect Jinja variable names and functions
     _JINJA_VAR_FUNCTION_PATTERN: Final[str] = r"[a-zA-Z_][a-zA-Z0-9_\|\'\"\(\)\, =\.\-]*"
 
-    # Jinja regular expressions
+    ## Pre-process conversion tooling regular expressions ##
+    # Finds `environ[]` used by a some recipe files. Requires a whitespace character to prevent matches with
+    # `os.environ[]`, which is very rare.
+    PRE_PROCESS_ENVIRON: Final[re.Pattern[str]] = re.compile(r"\s+environ\[(\"|')(.*)(\"|')\]")
+
+    ## Jinja regular expressions ##
     JINJA_SUB: Final[re.Pattern[str]] = re.compile(r"{{\s*" + _JINJA_VAR_FUNCTION_PATTERN + r"\s*}}")
     JINJA_FUNCTION_LOWER: Final[re.Pattern[str]] = re.compile(r"\|\s*lower")
     JINJA_LINE: Final[re.Pattern[str]] = re.compile(r"({%.*%}|{#.*#})\n")

--- a/conda_recipe_manager/parser/recipe_parser_convert.py
+++ b/conda_recipe_manager/parser/recipe_parser_convert.py
@@ -402,6 +402,15 @@ class RecipeParserConvert(RecipeParser):
             # found at the top-level. So for consistency, we sort on that ordering.
             self._sort_subtree_keys(output_path, TOP_LEVEL_KEY_SORT_ORDER)
 
+    @staticmethod
+    def pre_process_recipe_text(content: str) -> str:
+        """
+        TODO complete
+        :param content: Recipe file contents to pre-process
+        :returns: Pre-processed recipe file contents
+        """
+        return content
+
     def render_to_new_recipe_format(self) -> tuple[str, MessageTable]:
         """
         Takes the current recipe representation and renders it to the new format WITHOUT modifying the current recipe

--- a/conda_recipe_manager/parser/recipe_parser_convert.py
+++ b/conda_recipe_manager/parser/recipe_parser_convert.py
@@ -405,8 +405,8 @@ class RecipeParserConvert(RecipeParser):
     @staticmethod
     def pre_process_recipe_text(content: str) -> str:
         """
-        Takes the content of a recipe file and performs manipulations prior to the parsing stage. This is should be
-        seldom used to solve conversion issues.
+        Takes the content of a recipe file and performs manipulations prior to the parsing stage. This should be
+        used sparingly for solving conversion issues.
 
         Ideally the pre-processor phase is only used when:
           - There is no other feasible way to solve a conversion issue.

--- a/conda_recipe_manager/parser/recipe_parser_convert.py
+++ b/conda_recipe_manager/parser/recipe_parser_convert.py
@@ -417,9 +417,10 @@ class RecipeParserConvert(RecipeParser):
         :param content: Recipe file contents to pre-process
         :returns: Pre-processed recipe file contents
         """
-        # Convert the old JINJA `environ[""]` variable usage to the new `get.env("")` syntax. NOTE:
+        # Convert the old JINJA `environ[""]` variable usage to the new `get.env("")` syntax.
+        # NOTE:
         #   - This is mostly used by Bioconda recipes and R-based-packages in the `license_file` field.
-        #   - From our search, it looks like we never deal with more than one set of outer quotes with in the brackets
+        #   - From our search, it looks like we never deal with more than one set of outer quotes within the brackets
         replacements: list[tuple[str, str]] = []
         for groups in cast(list[str], Regex.PRE_PROCESS_ENVIRON.findall(content)):
             # Each match should return ["<quote char>", "<key>", "<quote_char>"]

--- a/tests/parser/test_recipe_parser_convert.py
+++ b/tests/parser/test_recipe_parser_convert.py
@@ -7,8 +7,28 @@ from __future__ import annotations
 
 import pytest
 
+from conda_recipe_manager.parser.recipe_parser_convert import RecipeParserConvert
 from conda_recipe_manager.parser.types import MessageCategory
 from tests.file_loading import TEST_FILES_PATH, load_file, load_recipe_convert
+
+
+@pytest.mark.parametrize(
+    "input_file,expected_file",
+    [
+        ("simple-recipe_environ.yaml", "pre-processed-simple-recipe_environ.yaml"),
+        ("simple-recipe.yaml", "simple-recipe.yaml"),  # Unchanged file
+    ],
+)
+def test_pre_process_recipe_text(input_file: str, expected_file: str) -> None:
+    """
+    Validates the pre-processor phase of the conversion process. A recipe file should come in
+    as a string and return a modified string, if applicable.
+    :param input_file: Test input recipe file name
+    :param expected_file: Name of the file containing the expected output of a test instance
+    """
+    assert RecipeParserConvert.pre_process_recipe_text(load_file(f"{TEST_FILES_PATH}/{input_file}")) == load_file(
+        f"{TEST_FILES_PATH}/{expected_file}"
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_aux_files/pre-processed-simple-recipe_environ.yaml
+++ b/tests/test_aux_files/pre-processed-simple-recipe_environ.yaml
@@ -1,0 +1,53 @@
+{% set zz_non_alpha_first = 42 %}
+{% set name = "types-toml" %}
+{% set version = "0.10.8.6" %}
+
+package:
+  name: {{ name|lower }}  # [unix]
+
+build:
+  number: 0
+  skip: true  # [py<37]
+  is_true: true
+
+# Comment above a top-level structure
+requirements:
+  empty_field1:
+  host:
+    - setuptools  # [unix]
+    - fakereq  # [unix] selector with comment
+  empty_field2:  # [unix and win] # selector with comment with comment symbol
+  run:
+    - python  # not a selector
+  empty_field3:
+
+about:
+  summary: This is a small recipe for testing
+  description: |
+    This is a PEP '561 type stub package for the toml package.
+    It can be used by type-checking tools like mypy, pyright,
+    pytype, PyCharm, etc. to check code that uses toml.
+  license: Apache-2.0 AND MIT
+
+multi_level:
+  list_1:
+    - foo
+    # Ensure a comment in a list is supported
+    - bar
+  list_2:
+    - cat
+    - {{ env.get('baz') }}
+    - mat
+  list_3:
+    - ls
+    - sl
+    - cowsay
+
+test_var_usage:
+  foo: {{ version }}
+  bar:
+    - baz
+    - {{ env.get("foobar") }}
+    - blah
+    - This {{ name }} is silly
+    - last

--- a/tests/test_aux_files/simple-recipe_environ.yaml
+++ b/tests/test_aux_files/simple-recipe_environ.yaml
@@ -1,0 +1,53 @@
+{% set zz_non_alpha_first = 42 %}
+{% set name = "types-toml" %}
+{% set version = "0.10.8.6" %}
+
+package:
+  name: {{ name|lower }}  # [unix]
+
+build:
+  number: 0
+  skip: true  # [py<37]
+  is_true: true
+
+# Comment above a top-level structure
+requirements:
+  empty_field1:
+  host:
+    - setuptools  # [unix]
+    - fakereq  # [unix] selector with comment
+  empty_field2:  # [unix and win] # selector with comment with comment symbol
+  run:
+    - python  # not a selector
+  empty_field3:
+
+about:
+  summary: This is a small recipe for testing
+  description: |
+    This is a PEP '561 type stub package for the toml package.
+    It can be used by type-checking tools like mypy, pyright,
+    pytype, PyCharm, etc. to check code that uses toml.
+  license: Apache-2.0 AND MIT
+
+multi_level:
+  list_1:
+    - foo
+    # Ensure a comment in a list is supported
+    - bar
+  list_2:
+    - cat
+    - {{ environ['baz'] }}
+    - mat
+  list_3:
+    - ls
+    - sl
+    - cowsay
+
+test_var_usage:
+  foo: {{ version }}
+  bar:
+    - baz
+    - {{ environ["foobar"] }}
+    - blah
+    - This {{ name }} is silly
+    - last


### PR DESCRIPTION
Fixes Issue #18 by way of adding a new recipe pre-processing phase to the conversion script. 

Although this particular issue could likely be fixed in the parser, there are seemingly not _that_ many recipes that use this `environ[""]` syntax and most that do use it, use it in a very specific way. I anticipate we will run into nastier problems that may require a pre-processing step, so this is at least a good candidate issue to test the waters.