### PR TITLE
Adds `--debug` flag to conversion script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ test-debug:		## runs test cases with debugging info enabled
 
 test-cov:		## checks test coverage requirements
 	$(PYTHON3) -m pytest -n auto --cov-config=.coveragerc --cov=$(SRC_DIR) \
-		$(TEST_DIR) --cov-fail-under=45 --cov-report term-missing
+		$(TEST_DIR) --cov-fail-under=80 --cov-report term-missing
 
 lint:			## runs the linter against the project
 	pylint --rcfile=.pylintrc $(SRC_DIR) $(TEST_DIR)

--- a/conda_recipe_manager/commands/convert.py
+++ b/conda_recipe_manager/commands/convert.py
@@ -147,13 +147,16 @@ def convert_file(file_path: Path, output: Optional[Path], print_output: bool, de
             e,
         )
 
-    # Print the initial parsed recipe, if requested
-    print_err("########## PARSED RECIPE FILE ##########", debug)
-    print_err(parser, debug)
+    # Print the initial parser, if requested
+    print_err("########## PARSED RECIPE FILE ##########", print_enabled=debug)
+    print_err(parser, print_enabled=debug)
 
     # Convert the recipe
     try:
-        conversion_result.content, conversion_result.msg_tbl = parser.render_to_new_recipe_format()
+        conversion_result.content, conversion_result.msg_tbl, debug_new_parser = parser.render_to_new_recipe_format()
+        # Print the new parser, if requested
+        print_err("########## CONVERTED RECIPE FILE ##########", print_enabled=debug)
+        print_err(debug_new_parser, print_enabled=debug)
     except Exception as e:  # pylint: disable=broad-exception-caught
         return _record_unrecoverable_failure(
             conversion_result,

--- a/conda_recipe_manager/parser/recipe_parser_convert.py
+++ b/conda_recipe_manager/parser/recipe_parser_convert.py
@@ -449,7 +449,7 @@ class RecipeParserConvert(RecipeParser):
         (As of writing there is no official name other than "the new recipe format")
         :returns: Returns a tuple containing:
             - The converted recipe, as a string
-            - A MessageTbl instance that contains error logging
+            - A `MessageTbl` instance that contains error logging
             - The `RecipeParser` instance containing the converted recipe file. USE FOR DEBUGGING PURPOSES ONLY!
         """
         # Approach: In the event that we want to expand support later, this function should be implemented in terms

--- a/conda_recipe_manager/parser/recipe_parser_convert.py
+++ b/conda_recipe_manager/parser/recipe_parser_convert.py
@@ -437,7 +437,7 @@ class RecipeParserConvert(RecipeParser):
 
         return content
 
-    def render_to_new_recipe_format(self) -> tuple[str, MessageTable]:
+    def render_to_new_recipe_format(self) -> tuple[str, MessageTable, RecipeParser]:
         """
         Takes the current recipe representation and renders it to the new format WITHOUT modifying the current recipe
         state.
@@ -447,6 +447,10 @@ class RecipeParserConvert(RecipeParser):
           - https://github.com/conda-incubator/ceps/blob/main/cep-14.md
 
         (As of writing there is no official name other than "the new recipe format")
+        :returns: Returns a tuple containing:
+            - The converted recipe, as a string
+            - A MessageTbl instance that contains error logging
+            - The `RecipeParser` instance containing the converted recipe file. USE FOR DEBUGGING PURPOSES ONLY!
         """
         # Approach: In the event that we want to expand support later, this function should be implemented in terms
         # of a `RecipeParser` tree. This will make it easier to build an upgrade-path, if we so choose to pursue one.
@@ -496,4 +500,4 @@ class RecipeParserConvert(RecipeParser):
         # "sensible" to a human reader.
         self._sort_subtree_keys("/", TOP_LEVEL_KEY_SORT_ORDER)
 
-        return self._new_recipe.render(), self._msg_tbl
+        return self._new_recipe.render(), self._msg_tbl, self._new_recipe

--- a/tests/parser/test_recipe_parser_convert.py
+++ b/tests/parser/test_recipe_parser_convert.py
@@ -120,7 +120,7 @@ def test_render_to_new_recipe_format(file_base: str, errors: list[str], warnings
     :param file_base: Base file name for both the input and the expected out
     """
     parser = load_recipe_convert(file_base)
-    result, tbl = parser.render_to_new_recipe_format()
+    result, tbl, _ = parser.render_to_new_recipe_format()
     assert result == load_file(f"{TEST_FILES_PATH}/new_format_{file_base}")
     assert tbl.get_messages(MessageCategory.ERROR) == errors
     assert tbl.get_messages(MessageCategory.WARNING) == warnings


### PR DESCRIPTION
Adds a `--debug` (and `-d`) flag to the conversion script. This flag prints debugging output to `STDERR`. For now it prints the initial parse-tree and the post-conversion parse-tree. 

I've been using this strategy informally for months to determine if a bug is caused by an incorrect parse tree or a failure of the rendering function.

This PR also raises the unit testing coverage minimum to 80%. This should have been raised when the project was ported to conda-incubator.

Here's a sample debug output of a parser instance:
```
--------------------
RecipeParser Instance
- Variables Table:
{
  "name": "boto",
  "version": "2.49.0"
}
- Selectors Table:
  [py2k]
    - asadmin -h -> /test/commands/0
    - taskadmin -h -> /test/commands/2
- is_modified?: False
- Tree:
/
  |- package
    |- name
      |- {{ name|lower }}
    |- version
      |- {{ version }}
  |- source
    |- fn
      |- {{ name }}-{{ version }}.tar.gz
    |- url
      |- https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
    |- sha256
      |- ea0d3b40a2d852767be77ca343b58a9e3a4b00d9db440efb8da74b4e58025e5a
  |- requirements
    |- host
      |- python
    |- run
      |- python
  |- build
    |- number
      |- 0
    |- script
      |- python setup.py install
  |- test
    |- commands
      |- asadmin -h
      |- s3put -h
      |- taskadmin -h
    |- imports
      |- boto
  |- about
    |- home
      |- https://github.com/boto/boto/
    |- license
      |- MIT
    |- summary
      |- Amazon Web Services Library
    |- description
      |- ['Boto aims to support the full breadth and depth of Amazon Web Services.', 'NOTE: Boto3, the next version of Boto, is stable and recommended for', 'general use.']
    |- doc_url
      |- http://docs.pythonboto.org/en/latest/
    |- doc_source_url
      |- https://github.com/boto/boto/blob/develop/docs/source/index.rst
    |- dev_url
      |- https://github.com/boto/boto/
--------------------


```