### PR TITLE
Fixes indentation edge case with lists under a collection element node

### DIFF
--- a/conda_recipe_manager/parser/recipe_parser.py
+++ b/conda_recipe_manager/parser/recipe_parser.py
@@ -532,15 +532,22 @@ class RecipeParser:
         # Don't render a `:` for the non-visible root node. Also don't render invisible collection nodes.
         if depth > -1 and not node.is_collection_element():
             list_prefix = ""
+            # Creating a copy of `spaces` scoped to this check prevents a scenario in which child nodes of this
+            # collection element are missing one indent-level. The indent now only applies to the collection element.
+            # Example:
+            #   - script:
+            #     - foo  # Incorrect
+            #       - foo  # Correct
+            tmp_spaces = spaces
             # Handle special cases for the "parent" key
             if node.list_member_flag:
                 list_prefix = "- "
                 depth_delta += 1
             if is_first_collection_child:
                 list_prefix = "- "
-                spaces = spaces[TAB_SPACE_COUNT:]
+                tmp_spaces = tmp_spaces[TAB_SPACE_COUNT:]
             # Nodes representing collections in a list have nothing to render
-            lines.append(f"{spaces}{list_prefix}{node.value}:  {node.comment}".rstrip())
+            lines.append(f"{tmp_spaces}{list_prefix}{node.value}:  {node.comment}".rstrip())
 
         for child in node.children:
             # Top-level empty-key edge case: Top level keys should have no additional indentation.

--- a/tests/parser/test_recipe_parser_convert.py
+++ b/tests/parser/test_recipe_parser_convert.py
@@ -97,6 +97,15 @@ def test_pre_process_recipe_text(input_file: str, expected_file: str) -> None:
             [],
             ["Required field missing: /about/license_url"],
         ),
+        # Regression: Tests for proper indentation of a list item inside a collection node element
+        (
+            "boto.yaml",
+            [],
+            [
+                "Required field missing: /about/license_file",
+                "Required field missing: /about/license_url",
+            ],
+        ),
         # TODO complete: The `rust.yaml` test contains many edge cases and selectors that aren't directly supported in
         # the new recipe format
         # (

--- a/tests/test_aux_files/boto.yaml
+++ b/tests/test_aux_files/boto.yaml
@@ -1,0 +1,41 @@
+{% set name = "boto" %}
+{% set version = "2.49.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: ea0d3b40a2d852767be77ca343b58a9e3a4b00d9db440efb8da74b4e58025e5a
+
+requirements:
+  host:
+    - python
+  run:
+    - python
+
+build:
+  number: 0
+  script: python setup.py install
+
+test:
+  commands:
+    - asadmin -h    # [py2k]
+    - s3put -h
+    - taskadmin -h  # [py2k]
+  imports:
+    - boto
+
+about:
+  home: https://github.com/boto/boto/
+  license: MIT
+  summary: Amazon Web Services Library
+  description: |
+    Boto aims to support the full breadth and depth of Amazon Web Services.
+    NOTE: Boto3, the next version of Boto, is stable and recommended for
+    general use.
+  doc_url: http://docs.pythonboto.org/en/latest/
+  doc_source_url: https://github.com/boto/boto/blob/develop/docs/source/index.rst
+  dev_url: https://github.com/boto/boto/

--- a/tests/test_aux_files/new_format_boto.yaml
+++ b/tests/test_aux_files/new_format_boto.yaml
@@ -1,0 +1,47 @@
+schema_version: 1
+
+context:
+  name: boto
+  version: 2.49.0
+
+package:
+  name: ${{ name|lower }}
+  version: ${{ version }}
+
+source:
+  fn: ${{ name }}-${{ version }}.tar.gz
+  url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/${{ name }}-${{ version }}.tar.gz
+  sha256: ea0d3b40a2d852767be77ca343b58a9e3a4b00d9db440efb8da74b4e58025e5a
+
+build:
+  number: 0
+  script: python setup.py install
+
+requirements:
+  host:
+    - python
+  run:
+    - python
+
+tests:
+  - python:
+      imports:
+        - boto
+      pip_check: false
+  - script:
+      - if: py2k
+        then: asadmin -h
+      - s3put -h
+      - if: py2k
+        then: taskadmin -h
+
+about:
+  license: MIT
+  summary: Amazon Web Services Library
+  description: |
+    Boto aims to support the full breadth and depth of Amazon Web Services.
+    NOTE: Boto3, the next version of Boto, is stable and recommended for
+    general use.
+  homepage: https://github.com/boto/boto/
+  repository: https://github.com/boto/boto/
+  documentation: http://docs.pythonboto.org/en/latest/


### PR DESCRIPTION
Fixes indentation edge case with lists under a collection element node.

Here's the example that caused this discovery (annotated with the correct answer):
```yaml
  - script:
      - if: py2k
        then: asadmin -h
    - s3put -h  # Incorrect
      - s3put -h  # Correct
      - if: py2k
        then: taskadmin -h
```

This improper indentation causes an issue when `rattler-build` executes a dry-run on the recipe:
```
 ╭─ Finding outputs from recipe
 │
 ╰─────────────────── (took 0 seconds)
Error:   × Parsing: failed to parse YAML: while parsing a block mapping, did not find expected key
    ╭─[34:7]
 33 │         then: asadmin -h
 34 │     - s3put -h
    ·       ────┬───
    ·           ╰── here
 35 │       - if: py2k
    ╰────
```

Also adds a regression test to catch this issue if it happens again.