### PR TITLE
Quick bug fixes

### DIFF
--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -23,8 +23,8 @@ jobs:
           - bioconda_recipes_04
         include:
           - test-directory: anaconda_recipes_01
-            convert-success: 0.80
-            rattler-success: 0.50
+            convert-success: 0.90
+            rattler-success: 0.65
           - test-directory: bioconda_recipes_01
             convert-success: 0.55
             rattler-success: 0.05
@@ -39,8 +39,8 @@ jobs:
             rattler-success: 0.30
           # 2,000 randomly selected conda-forge recipes
           - test-directory: conda_forge_recipes_01
-            convert-success: 0.75
-            rattler-success: 0.70
+            convert-success: 0.90
+            rattler-success: 0.65
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -52,11 +52,14 @@ jobs:
         with:
           python-version: "3.11"
       - name: Convert recipes and dry-run rattler-build
+        # NOTE: `pipefail` must be enabled in order get the exit code from the conda-recipe-manager commands when
+        #       the output is piped into `tee`
         run: |
           source $CONDA/bin/activate
           conda activate conda-recipe-manager
           conda install -y -c conda-forge rattler-build
           mkdir -p logs
+          set -o pipefail
           conda-recipe-manager \
             convert -t -m ${{ matrix.convert-success }} -o recipe.yaml test_data/recipes_v0/${{ matrix.test-directory }} \
             | tee logs/convert_${{ matrix.test-directory }}.log
@@ -87,6 +90,7 @@ jobs:
         run: |
           source $CONDA/bin/activate
           conda activate conda-recipe-manager
+          set -o pipefail
           scripts/parse_ci_output.py logs/ | tee report.json
           echo -e "Integration Report:\n\`\`\`json\n" >> ${GITHUB_STEP_SUMMARY}
           cat report.json >> ${GITHUB_STEP_SUMMARY}

--- a/conda_recipe_manager/parser/recipe_parser_convert.py
+++ b/conda_recipe_manager/parser/recipe_parser_convert.py
@@ -238,7 +238,7 @@ class RecipeParserConvert(RecipeParser):
 
     def _upgrade_build_section(self, base_package_paths: list[str]) -> None:
         """
-        Upgrades/converts the `about` section(s) of a recipe file.
+        Upgrades/converts the `build` section(s) of a recipe file.
         :param base_package_paths: Set of base paths to process that could contain this section.
         """
         for base_path in base_package_paths:
@@ -254,7 +254,7 @@ class RecipeParserConvert(RecipeParser):
                 self._patch_and_log({"op": "move", "from": old_re_path, "path": new_re_path})
             # `ignore_run_exports`
             old_ire_path = RecipeParser.append_to_path(base_path, "/build/ignore_run_exports")
-            if self._v1_recipe.contains_value(old_re_path):
+            if self._v1_recipe.contains_value(old_ire_path):
                 requirements_path = RecipeParser.append_to_path(base_path, "/requirements")
                 new_ire_path = RecipeParser.append_to_path(base_path, "/requirements/ignore_run_exports")
                 if not self._v1_recipe.contains_value(requirements_path):
@@ -281,6 +281,19 @@ class RecipeParserConvert(RecipeParser):
 
             # Canonically sort this section
             self._sort_subtree_keys(build_path, V1_BUILD_SECTION_KEY_SORT_ORDER)
+
+    def _upgrade_requirements_section(self, base_package_paths: list[str]) -> None:
+        """
+        Upgrades/converts the `requirements` section(s) of a recipe file.
+        :param base_package_paths: Set of base paths to process that could contain this section.
+        """
+        for base_path in base_package_paths:
+            requirements_path = RecipeParser.append_to_path(base_path, "/requirements")
+            if not self._v1_recipe.contains_value(requirements_path):
+                continue
+
+            # Simple transformations
+            self._patch_move_base_path(requirements_path, "/run_constrained", "/run_constraints")
 
     def _upgrade_about_section(self, base_package_paths: list[str]) -> None:
         """
@@ -513,6 +526,7 @@ class RecipeParserConvert(RecipeParser):
         # Upgrade common sections found in a recipe
         self._upgrade_source_section(base_package_paths)
         self._upgrade_build_section(base_package_paths)
+        self._upgrade_requirements_section(base_package_paths)
         self._upgrade_about_section(base_package_paths)
         self._upgrade_test_section(base_package_paths)
         self._upgrade_multi_output(base_package_paths)

--- a/conda_recipe_manager/parser/recipe_parser_convert.py
+++ b/conda_recipe_manager/parser/recipe_parser_convert.py
@@ -197,6 +197,17 @@ class RecipeParserConvert(RecipeParser):
                 self._patch_and_log(patch)
                 self._v1_recipe.remove_selector(selector_path)
 
+    def _correct_common_misspellings(self) -> None:
+        """
+        Corrects common spelling mistakes in field names.
+        """
+        # "If I had a nickel for every time `skip` was misspelled, I would have several nickels. Which isn't a lot, but
+        #  it is weird that it has happened multiple times."
+        #                                                             - Dr. Doofenshmirtz, probably
+        self._patch_move_base_path("/build", "skipt", "skip")
+        self._patch_move_base_path("/build", "skips", "skip")
+        self._patch_move_base_path("/build", "Skip", "skip")
+
     def _upgrade_source_section(self, base_package_paths: list[str]) -> None:
         """
         Upgrades/converts the `source` section(s) of a recipe file.
@@ -522,6 +533,10 @@ class RecipeParserConvert(RecipeParser):
         base_package_paths: Final[list[str]] = self._v1_recipe.get_package_paths()
 
         # TODO Fix: comments are not preserved with patch operations (add a flag to `patch()`?)
+
+        # There are a number of recipe files that contain the same misspellings. This is an attempt to
+        # solve the more common issues.
+        self._correct_common_misspellings()
 
         # Upgrade common sections found in a recipe
         self._upgrade_source_section(base_package_paths)

--- a/tests/test_aux_files/v1_format/v1_cctools-ld64.yaml
+++ b/tests/test_aux_files/v1_format/v1_cctools-ld64.yaml
@@ -101,11 +101,11 @@ outputs:
       version: ${{ cctools_version }}
     build:
       number: 1
-      ignore_run_exports:
-        - zlib
     requirements:
       run:
         - llvm-lto-tapi
+      ignore_run_exports:
+        - zlib
     about:
       license: Apple Public Source License 2.0
       license_file: cctools/APPLE_LICENSE
@@ -117,8 +117,6 @@ outputs:
       version: ${{ ld64_version }}
     build:
       number: 1
-      ignore_run_exports:
-        - zlib
     requirements:
       host:
         - llvm-lto-tapi
@@ -128,6 +126,8 @@ outputs:
         - llvm-lto-tapi
         - if: osx
           then: libcxx
+      ignore_run_exports:
+        - zlib
     about:
       license: Apple Public Source License 2.0
       license_file: cctools/ld64/APPLE_LICENSE

--- a/tests/test_aux_files/v1_format/v1_huggingface_hub.yaml
+++ b/tests/test_aux_files/v1_format/v1_huggingface_hub.yaml
@@ -38,7 +38,7 @@ requirements:
     - requests
     - tqdm >=4.42.1
     - typing-extensions >=3.7.4.3
-  run_constrained:
+  run_constraints:
     - fastai >=2.4
     - fastcore >=1.3.27
     - InquirerPy ==0.3.4


### PR DESCRIPTION
A few quick bug fixes I found and fixed today.

Also includes some minor spelling corrections that happen on occasion. They don't happen a lot but it's weird they happen more than once.

Also fixes an issue where the integration tests may silently fail to meet the testing threshold. The `pipefail` shell option was not enabled, causing `tee` to always return `0`  