### PR TITLE
JINJA substitution fixes

### DIFF
--- a/conda_recipe_manager/commands/rattler_bulk_build.py
+++ b/conda_recipe_manager/commands/rattler_bulk_build.py
@@ -7,13 +7,14 @@ from __future__ import annotations
 
 import json
 import multiprocessing as mp
+import operator
 import re
 import subprocess
 import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Final, cast
+from typing import Final, Optional, cast
 
 import click
 
@@ -79,6 +80,37 @@ def build_recipe(file: Path, path: Path, args: list[str]) -> tuple[str, BuildRes
     )
 
 
+def create_debug_file(debug_log: Path, results: dict[str, BuildResult], error_histogram: dict[str, int]) -> None:
+    """
+    Generates a debug file containing an organized dump of all the recipes that got a particular error message.
+    :param debug_log: Log file to write to
+    :param results:
+    :param error_histogram:
+    """
+    # Metric-driven development: list the recipes associated with each failure, tracking how many recipes the failure
+    # is seen in.
+
+    errors = []
+    # TODO: This could probably be done more efficiently, but at our current scale for a debugging tool, this is fine.
+    for cur_error in error_histogram.keys():
+        recipes: list[str] = []
+        for file, build_result in results.items():
+            if cur_error in build_result.errors:
+                recipes.append(file)
+
+        errors.append(
+            {
+                "error": cur_error,
+                "recipe_count": len(recipes),
+                "recipes": recipes,
+            }
+        )
+
+    errors.sort(key=operator.itemgetter("recipe_count"), reverse=True)
+    dump = {"errors": errors}
+    debug_log.write_text(json.dumps(dump, indent=2), encoding="utf-8")
+
+
 @click.command(
     short_help="Given a directory, performs a bulk rattler-build operation. Assumes rattler-build is installed.",
     context_settings=cast(
@@ -103,11 +135,19 @@ def build_recipe(file: Path, path: Path, args: list[str]) -> tuple[str, BuildRes
     is_flag=True,
     help="Truncates logging. On large tests in a GitHub CI environment, this can eliminate log buffering issues.",
 )
+@click.option(
+    "--debug-log",
+    "-l",
+    type=click.Path(exists=False, file_okay=True, dir_okay=False, path_type=Path),  # type: ignore[misc]
+    help="Dumps a large debug log to the file specified.",
+)
 @click.pass_context
-def rattler_bulk_build(ctx: click.Context, path: Path, min_success_rate: float, truncate: bool) -> None:
+def rattler_bulk_build(
+    ctx: click.Context, path: Path, min_success_rate: float, truncate: bool, debug_log: Optional[Path]
+) -> None:
     """
     Given a directory of feedstock repositories, performs multiple recipe builds using rattler-build.
-    All unknown options and arguments for this script are passed directly to `rattler-build build`.
+    All unknown trailing options and arguments for this script are passed directly to `rattler-build build`.
     NOTE:
         - The build command is run as `rattler-build build -r <recipe.yaml> <ARGS>`
         - rattler-build errors are dumped to STDERR
@@ -169,6 +209,9 @@ def rattler_bulk_build(ctx: click.Context, path: Path, min_success_rate: float, 
     }
     if not truncate:
         final_output["recipes_with_build_error_code"] = recipes_with_errors
+
+    if debug_log is not None:
+        create_debug_file(debug_log, results, error_histogram)
 
     print(json.dumps(final_output, indent=2))
     sys.exit(SUCCESS if percent_success >= min_success_rate else MISSED_SUCCESS_THRESHOLD)

--- a/conda_recipe_manager/commands/rattler_bulk_build.py
+++ b/conda_recipe_manager/commands/rattler_bulk_build.py
@@ -98,6 +98,8 @@ def create_debug_file(debug_log: Path, results: dict[str, BuildResult], error_hi
             if cur_error in build_result.errors:
                 recipes.append(file)
 
+        # Sort recipes by name. In theory, this will group similar recipes together (like R packages)
+        recipes.sort()
         errors.append(
             {
                 "error": cur_error,

--- a/conda_recipe_manager/parser/_types.py
+++ b/conda_recipe_manager/parser/_types.py
@@ -123,6 +123,9 @@ class Regex:
     JINJA_FUNCTION_LOWER: Final[re.Pattern[str]] = re.compile(r"\|\s*lower")
     JINJA_LINE: Final[re.Pattern[str]] = re.compile(r"({%.*%}|{#.*#})\n")
     JINJA_SET_LINE: Final[re.Pattern[str]] = re.compile(r"{%\s*set\s*" + _JINJA_VAR_FUNCTION_PATTERN + r"\s*=.*%}\s*\n")
+    # Useful for replacing the older `{{` JINJA substitution with the newer `${{` WITHOUT accidentally doubling-up the
+    # newer syntax when multiple replacements are possible.
+    JINJA_REPLACE_V0_STARTING_MARKER: Final[re.Pattern[str]] = re.compile(r"(?<!\$)\{\{")
 
     SELECTOR: Final[re.Pattern[str]] = re.compile(r"\[.*\]")
     # Detects the 6 common variants (3 |'s, 3 >'s). See this guide for more info:

--- a/conda_recipe_manager/parser/_types.py
+++ b/conda_recipe_manager/parser/_types.py
@@ -89,6 +89,23 @@ V1_TEST_SECTION_KEY_SORT_ORDER: Final[dict[str, int]] = {
     "downstream": 40,
 }
 
+# Mapping that attempts to correct common SPDX licensing mistakes (`MISTAKE` (all uppercase) -> `Corrected`)
+SPDX_COMMON_MISSPELLINGS_TBL: Final[dict[str, str]] = {
+    #### Apache ####
+    "APACHE LICENSE 1.0": "Apache-1.0",
+    "APACHE LICENSE 1.1": "Apache-1.1",
+    "APACHE LICENSE 2.0": "Apache-2.0",
+    #### BSD ####
+    "BSD 1-CLAUSE": "BSD-1-Clause",
+    'BSD 2-CLAUSE "SIMPLIFIED"': "BSD-2-Clause",  # See: https://spdx.org/licenses/BSD-2-Clause.html
+    "BSD_2_CLAUSE": "BSD-2-Clause",
+    "BSD 3-CLAUSE": "BSD-3-Clause",
+    "BSD_3_CLAUSE": "BSD-3-Clause",
+    #### GPL ####
+    "GPL-2": "GPL-2.0",
+    "GPL-3": "GPL-3.0",
+}
+
 #### Private Classes (Not to be used external to the `parser` module) ####
 
 # NOTE: The classes put in this file should be structures (NamedTuples) and very small support classes that don't make

--- a/conda_recipe_manager/parser/recipe_parser_convert.py
+++ b/conda_recipe_manager/parser/recipe_parser_convert.py
@@ -150,7 +150,8 @@ class RecipeParserConvert(RecipeParser):
                     MessageCategory.WARNING, f"A non-string value was found as a JINJA substitution: {value}"
                 )
                 continue
-            value = value.replace("{{", "${{")
+            # Safely replace `{{` but not any existing `${{` instances
+            value = Regex.JINJA_REPLACE_V0_STARTING_MARKER.sub("${{", value)
             self._patch_and_log({"op": "replace", "path": path, "value": value})
 
     def _upgrade_selectors_to_conditionals(self) -> None:
@@ -174,7 +175,6 @@ class RecipeParserConvert(RecipeParser):
                 patch: JsonPatchType = {
                     "op": "replace",
                     "path": selector_path,
-                    # TODO: Sometimes this gets doubled up: $${{ true if win }}
                     "value": "${{ true if " + bool_expression + " }}",
                 }
                 # `skip` is special and needs to be a list of boolean expressions.

--- a/conda_recipe_manager/parser/recipe_parser_convert.py
+++ b/conda_recipe_manager/parser/recipe_parser_convert.py
@@ -13,6 +13,7 @@ from conda_recipe_manager.parser._node import Node
 from conda_recipe_manager.parser._traverse import traverse
 from conda_recipe_manager.parser._types import (
     ROOT_NODE_VALUE,
+    SPDX_COMMON_MISSPELLINGS_TBL,
     TOP_LEVEL_KEY_SORT_ORDER,
     V1_BUILD_SECTION_KEY_SORT_ORDER,
     V1_SOURCE_SECTION_KEY_SORT_ORDER,
@@ -45,13 +46,16 @@ class RecipeParserConvert(RecipeParser):
 
     ## Patch utility functions ##
 
-    def _patch_and_log(self, patch: JsonPatchType) -> None:
+    def _patch_and_log(self, patch: JsonPatchType) -> bool:
         """
         Convenience function that logs failed patches to the message table.
         :param patch: Patch operation to perform
+        :returns: Forwards patch results for further logging/error handling
         """
-        if not self._v1_recipe.patch(patch):
+        result: Final[bool] = self._v1_recipe.patch(patch)
+        if not result:
             self._msg_tbl.add_message(MessageCategory.ERROR, f"Failed to patch: {patch}")
+        return result
 
     def _patch_add_missing_path(self, base_path: str, ext: str, value: JsonType = None) -> None:
         """
@@ -309,6 +313,30 @@ class RecipeParserConvert(RecipeParser):
             # Simple transformations
             self._patch_move_base_path(requirements_path, "/run_constrained", "/run_constraints")
 
+    def _fix_bad_licenses(self, about_path: str) -> None:
+        """
+        Attempt to correct licenses to match SPDX-recognized names.
+
+        For now, this does not call-out to an SPDX database. Instead, we attempt to correct common mistakes.
+        :param about_path: Path to the `about` section, where the `license` field is located.
+        """
+        license_path: Final[str] = RecipeParser.append_to_path(about_path, "/license")
+        old_license: Final[Optional[str]] = cast(Optional[str], self._v1_recipe.get_value(license_path, default=None))
+        if old_license is None:
+            return
+
+        old_license_sanitized: Final[str] = old_license.upper().strip()
+
+        if old_license_sanitized not in SPDX_COMMON_MISSPELLINGS_TBL:
+            return
+
+        new_license: Final[str] = SPDX_COMMON_MISSPELLINGS_TBL[old_license_sanitized]
+        # Alert the user that a patch was made, in case it needs manual verification
+        if self._patch_and_log({"op": "replace", "path": license_path, "value": new_license}):
+            self._msg_tbl.add_message(
+                MessageCategory.WARNING, f"Changed {license_path} from `{old_license}` to `{new_license}`"
+            )
+
     def _upgrade_about_section(self, base_package_paths: list[str]) -> None:
         """
         Upgrades/converts the `about` section of a recipe file.
@@ -339,7 +367,7 @@ class RecipeParserConvert(RecipeParser):
             for old, new in about_rename_mapping:
                 self._patch_move_base_path(about_path, old, new)
 
-            # TODO validate: /about/license must be SPDX recognized.
+            self._fix_bad_licenses(about_path)
 
             # Remove deprecated `about` fields
             for field in about_deprecated:

--- a/tests/parser/test_recipe_parser_convert.py
+++ b/tests/parser/test_recipe_parser_convert.py
@@ -94,6 +94,12 @@ def test_pre_process_recipe_text(input_file: str, expected_file: str) -> None:
             [],
             [],
         ),
+        # Regression: Tests scenarios where the newer `${{ }}` substitutions got doubled up, causing: `$${{ foo }}`
+        (
+            "regression_jinja_sub.yaml",
+            [],
+            [],
+        ),
         # TODO complete: The `rust.yaml` test contains many edge cases and selectors that aren't directly supported in
         # the V1 recipe format
         # (

--- a/tests/test_aux_files/regression_jinja_sub.yaml
+++ b/tests/test_aux_files/regression_jinja_sub.yaml
@@ -1,0 +1,25 @@
+{% set name = "types-toml" %}
+{% set version = "0.10.8.6" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/{{name}}/source/{{version}}/{{version}}/{{version}}
+  sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
+  fn: ${{ name }}-${{ version }}.tar.gz
+
+build:
+  number: 0
+  merge_build_host: True  # [win]
+
+requirements:
+  host:
+    - python
+  run:
+    - python
+
+about:
+  home: https://github.com/python/typeshed
+  summary: Simple egression test for various JINJA substitution errors

--- a/tests/test_aux_files/v1_format/v1_regression_jinja_sub.yaml
+++ b/tests/test_aux_files/v1_format/v1_regression_jinja_sub.yaml
@@ -1,0 +1,28 @@
+schema_version: 1
+
+context:
+  name: types-toml
+  version: 0.10.8.6
+
+package:
+  name: ${{ name|lower }}
+  version: ${{ version }}
+
+source:
+  url: https://pypi.io/packages/${{name}}/source/${{version}}/${{version}}/${{version}}
+  sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
+  file_name: ${{ name }}-${{ version }}.tar.gz
+
+build:
+  number: 0
+  merge_build_and_host_envs: ${{ true if win }}
+
+requirements:
+  host:
+    - python
+  run:
+    - python
+
+about:
+  summary: Simple egression test for various JINJA substitution errors
+  homepage: https://github.com/python/typeshed


### PR DESCRIPTION
I found some scenarios where the JINJA substitution upgrades can fail and cause doubling up of the dollar sign (i.e. `$${{ foo }}` is added to the file instead of `${{ foo }}`.

This PR addresses those issues and adds regression tests to prevent this from happening again.

Also:
- Adds some new debug logging options to `rattler-bulk-build`
- Adds some simple license corrections to the SPDX format