### PR TITLE
Adds missing build transforms

### DIFF
--- a/conda_recipe_manager/parser/_types.py
+++ b/conda_recipe_manager/parser/_types.py
@@ -89,6 +89,12 @@ V1_TEST_SECTION_KEY_SORT_ORDER: Final[dict[str, int]] = {
     "downstream": 40,
 }
 
+# Canonical sort order for the V1 Python test element
+V1_PYTHON_TEST_KEY_SORT_ORDER: Final[dict[str, int]] = {
+    "imports": 0,
+    "pip_check": 10,
+}
+
 #### Private Classes (Not to be used external to the `parser` module) ####
 
 # NOTE: The classes put in this file should be structures (NamedTuples) and very small support classes that don't make

--- a/conda_recipe_manager/parser/recipe_parser.py
+++ b/conda_recipe_manager/parser/recipe_parser.py
@@ -226,7 +226,7 @@ class RecipeParser:
         if not isinstance(value, PRIMITIVES_TUPLE):
             # Although not technically required by YAML, we add the optional spacing for human readability.
             return RecipeParser(  # pylint: disable=protected-access
-                yaml.dump(value, Dumper=ForceIndentDumper)  # type: ignore[misc]
+                yaml.dump(value, Dumper=ForceIndentDumper, sort_keys=False)  # type: ignore[misc]
             )._root.children
 
         # Primitives can be safely stringified to generate a parse tree.

--- a/conda_recipe_manager/parser/recipe_parser_convert.py
+++ b/conda_recipe_manager/parser/recipe_parser_convert.py
@@ -294,6 +294,8 @@ class RecipeParserConvert(RecipeParser):
             self._patch_move_new_path(build_path, "/entry_points", "/python")
 
             # New `dynamic_linking` section changes
+            self._patch_move_new_path(build_path, "/rpaths", "/dynamic_linking", "/rpaths")
+            self._patch_move_new_path(build_path, "/binary_relocation", "/dynamic_linking", "/binary_relocation")
             self._patch_move_new_path(
                 build_path, "/missing_dso_whitelist", "/dynamic_linking", "/missing_dso_allowlist"
             )

--- a/conda_recipe_manager/parser/recipe_parser_convert.py
+++ b/conda_recipe_manager/parser/recipe_parser_convert.py
@@ -146,7 +146,7 @@ class RecipeParserConvert(RecipeParser):
         """
         # Convert the JINJA variable table to a `context` section. Empty tables still add the `context` section for
         # future developers' convenience.
-        context_obj: dict[str,str] = {}
+        context_obj: dict[str, str] = {}
         for name, value in self._v1_recipe._vars_tbl.items():  # pylint: disable=protected-access
             # Filter-out any value not covered in the V1 format
             if not isinstance(value, (str, int, float, bool)):
@@ -494,6 +494,11 @@ class RecipeParserConvert(RecipeParser):
                 self._patch_add_missing_path(test_path, "/python")
                 self._patch_move_base_path(test_path, "/imports", "/python/imports")
             self._patch_move_base_path(test_path, "/downstreams", "/downstream")
+
+            # Canonically sort the python section, if it exists
+            python_test_path = RecipeParser.append_to_path(test_path, "/python")
+            if self._v1_recipe.contains_value(python_test_path):
+                self._sort_subtree_keys(python_test_path, V1_PYTHON_TEST_KEY_SORT_ORDER)
 
             # Move `test` to `tests` and encapsulate the pre-existing object into a list
             new_test_path = f"{test_path}s"

--- a/conda_recipe_manager/parser/recipe_parser_convert.py
+++ b/conda_recipe_manager/parser/recipe_parser_convert.py
@@ -16,6 +16,7 @@ from conda_recipe_manager.parser._types import (
     ROOT_NODE_VALUE,
     TOP_LEVEL_KEY_SORT_ORDER,
     V1_BUILD_SECTION_KEY_SORT_ORDER,
+    V1_PYTHON_TEST_KEY_SORT_ORDER,
     V1_SOURCE_SECTION_KEY_SORT_ORDER,
     Regex,
 )

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,7 +48,6 @@ test:
 about:
   home: https://github.com/anaconda/conda-recipe-manager
   license: BSD-3-Clause
-  license_family: BSD
   license_file: LICENSE
   license_url: https://github.com/anaconda/conda-recipe-manager/blob/main/LICENSE
   summary: Helper tool for recipes on aggregate.

--- a/tests/parser/test_recipe_parser_convert.py
+++ b/tests/parser/test_recipe_parser_convert.py
@@ -51,19 +51,26 @@ def test_pre_process_recipe_text(input_file: str, expected_file: str) -> None:
         (
             "huggingface_hub.yaml",
             [],
-            [],
+            [
+                "Field at `/about/license_family` is no longer supported.",
+            ],
         ),
         (
             "types-toml.yaml",
             [],
-            ["Could not patch unrecognized license: `Apache-2.0 AND MIT`"],
+            [
+                "Could not patch unrecognized license: `Apache-2.0 AND MIT`",
+                "Field at `/about/license_family` is no longer supported.",
+            ],
         ),
         # Regression test: Contains a `test` section that caused an empty dictionary to be inserted in the conversion
         # process, causing an index-out-of-range exception.
         (
             "pytest-pep8.yaml",
             [],
-            [],
+            [
+                "Field at `/about/doc_source_url` is no longer supported.",
+            ],
         ),
         # Regression test: Contains selectors and test section data that caused previous conversion issues.
         (
@@ -74,19 +81,25 @@ def test_pre_process_recipe_text(input_file: str, expected_file: str) -> None:
                 "A non-list item had a selector at: /outputs/1/script",
                 "A non-list item had a selector at: /outputs/0/script",
                 "A non-list item had a selector at: /outputs/1/script",
+                "Field at `/about/license_family` is no longer supported.",
             ],
         ),
         # Tests for transformations related to the new `build/dynamic_linking` section
         (
             "dynamic-linking.yaml",
             [],
-            ["Could not patch unrecognized license: `Apache-2.0 AND MIT`"],
+            [
+                "Could not patch unrecognized license: `Apache-2.0 AND MIT`",
+                "Field at `/about/license_family` is no longer supported.",
+            ],
         ),
         # Regression: Tests for proper indentation of a list item inside a collection node element
         (
             "boto.yaml",
             [],
-            [],
+            [
+                "Field at `/about/doc_source_url` is no longer supported.",
+            ],
         ),
         # Regression: Tests a recipe that has multiple `source`` objects in `/source` AND an `about` per `output`
         # TODO Issue #50 tracks an edge case caused by this project that is not currently handled.
@@ -95,7 +108,9 @@ def test_pre_process_recipe_text(input_file: str, expected_file: str) -> None:
             [],
             [
                 "Changed /outputs/0/about/license from `Apple Public Source License 2.0` to " "`APSL-2.0`",
+                "Field at `/outputs/0/about/license_family` is no longer supported.",
                 "Changed /outputs/1/about/license from `Apple Public Source License 2.0` to " "`APSL-2.0`",
+                "Field at `/outputs/1/about/license_family` is no longer supported.",
             ],
         ),
         # Regression: Tests scenarios where the newer `${{ }}` substitutions got doubled up, causing: `$${{ foo }}`

--- a/tests/test_aux_files/simple-recipe_test_patch_add.yaml
+++ b/tests/test_aux_files/simple-recipe_test_patch_add.yaml
@@ -48,11 +48,11 @@ multi_level:
   list_3:
     - ls
     - George:
-        has_mop: false
         role: owner
+        has_mop: false
       Stanley:
-        has_mop: true
         role: janitor
+        has_mop: true
     - sl
     - cowsay
 

--- a/tests/test_aux_files/v1_format/v1_multi-output.yaml
+++ b/tests/test_aux_files/v1_format/v1_multi-output.yaml
@@ -1,7 +1,5 @@
 schema_version: 1
 
-context:
-
 outputs:
   - package:
       name: libdb


### PR DESCRIPTION
Found some small missing build section transformations. These missing transforms are occasionally seen in R packages and should help improve compatibility with `rattler-build`.

Also:
- Improves the deprecated field system
- Creating a new function that standardizes how we handle deprecated fields
- Provides the user a warning when a deprecated field has been removed.
- No longer emits empty `context` objects