### PR TITLE
Adds missing transforms for "git source" fields

### DIFF
--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -24,23 +24,23 @@ jobs:
         include:
           - test-directory: anaconda_recipes_01
             convert-success: 0.90
-            rattler-success: 0.70
+            rattler-success: 0.75
           - test-directory: bioconda_recipes_01
             convert-success: 0.55
-            rattler-success: 0.10
+            rattler-success: 0.35
           - test-directory: bioconda_recipes_02
             convert-success: 0.60
-            rattler-success: 0.25
+            rattler-success: 0.45
           - test-directory: bioconda_recipes_03
             convert-success: 0.85
-            rattler-success: 0.30
+            rattler-success: 0.55
           - test-directory: bioconda_recipes_04
             convert-success: 0.85
-            rattler-success: 0.45
+            rattler-success: 0.60
           # 2,000 randomly selected conda-forge recipes
           - test-directory: conda_forge_recipes_01
             convert-success: 0.90
-            rattler-success: 0.65
+            rattler-success: 0.70
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/conda_recipe_manager/parser/recipe_parser_convert.py
+++ b/conda_recipe_manager/parser/recipe_parser_convert.py
@@ -703,7 +703,7 @@ class RecipeParserConvert(RecipeParser):
 
         return content
 
-    def render_to_v1_recipe_format(self) -> tuple[str, MessageTable, RecipeParser]:
+    def render_to_v1_recipe_format(self) -> tuple[str, MessageTable, str]:
         """
         Takes the current recipe representation and renders it to the V1 format WITHOUT modifying the current recipe
         state.
@@ -715,7 +715,7 @@ class RecipeParserConvert(RecipeParser):
         :returns: Returns a tuple containing:
             - The converted recipe, as a string
             - A `MessageTbl` instance that contains error logging
-            - The `RecipeParser` instance containing the converted recipe file. USE FOR DEBUGGING PURPOSES ONLY!
+            - Converted recipe file debug string. USE FOR DEBUGGING PURPOSES ONLY!
         """
         # Approach: In the event that we want to expand support later, this function should be implemented in terms
         # of a `RecipeParser` tree. This will make it easier to build an upgrade-path, if we so choose to pursue one.
@@ -771,4 +771,4 @@ class RecipeParserConvert(RecipeParser):
         # "sensible" to a human reader.
         self._sort_subtree_keys("/", TOP_LEVEL_KEY_SORT_ORDER)
 
-        return self._v1_recipe.render(), self._msg_tbl, self._v1_recipe
+        return self._v1_recipe.render(), self._msg_tbl, str(self._v1_recipe)

--- a/conda_recipe_manager/parser/recipe_parser_convert.py
+++ b/conda_recipe_manager/parser/recipe_parser_convert.py
@@ -284,6 +284,12 @@ class RecipeParserConvert(RecipeParser):
                 self._patch_move_base_path(src_path, "/fn", "/file_name")
                 self._patch_move_base_path(src_path, "/folder", "/target_directory")
 
+                # `git` source transformations (`conda` does not appear to support all of the new features)
+                self._patch_move_base_path(src_path, "/git_url", "/git")
+                self._patch_move_base_path(src_path, "/git_tag", "/tag")
+                self._patch_move_base_path(src_path, "/git_rev", "/rev")
+                self._patch_move_base_path(src_path, "/git_depth", "/depth")
+
                 # Canonically sort this section
                 self._sort_subtree_keys(src_path, V1_SOURCE_SECTION_KEY_SORT_ORDER)
 

--- a/tests/parser/test_recipe_parser_convert.py
+++ b/tests/parser/test_recipe_parser_convert.py
@@ -142,6 +142,12 @@ def test_pre_process_recipe_text(input_file: str, expected_file: str) -> None:
             [],
             [],
         ),
+        # Ensures git source fields are transformed properly
+        (
+            "git-src.yaml",
+            [],
+            [],
+        ),
         # TODO complete: The `rust.yaml` test contains many edge cases and selectors that aren't directly supported in
         # the V1 recipe format
         # (

--- a/tests/test_aux_files/git-src.yaml
+++ b/tests/test_aux_files/git-src.yaml
@@ -1,0 +1,33 @@
+{% set name = "git-src" %}
+{% set version = "0.10.8.6" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  git_url: https://github.com/conda-incubator/conda-recipe-manager.git
+  git_tag: v1.0.0
+  git_rev: 1
+  git_depth: 0
+  sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
+
+build:
+  number: 0
+  skip: true  # [py<37]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python
+  run:
+    - python
+
+about:
+  home: https://github.com/python/typeshed
+  summary: Typing stubs for toml
+  description: Tests recipes that use git source fields
+  license: MIT
+  license_file: LICENSE
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://pypi.org/project/types-toml/

--- a/tests/test_aux_files/v1_format/v1_git-src.yaml
+++ b/tests/test_aux_files/v1_format/v1_git-src.yaml
@@ -1,0 +1,37 @@
+schema_version: 1
+
+context:
+  name: git-src
+  version: 0.10.8.6
+
+package:
+  name: ${{ name|lower }}
+  version: ${{ version }}
+
+source:
+  sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
+  git: https://github.com/conda-incubator/conda-recipe-manager.git
+  tag: v1.0.0
+  rev: 1
+  depth: 0
+
+build:
+  number: 0
+  skip:
+    - py<37
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python
+  run:
+    - python
+
+about:
+  summary: Typing stubs for toml
+  description: Tests recipes that use git source fields
+  license: MIT
+  license_file: LICENSE
+  homepage: https://github.com/python/typeshed
+  repository: https://github.com/python/typeshed
+  documentation: https://pypi.org/project/types-toml/


### PR DESCRIPTION
Adds transformations for `git_url` and other fields that were previously missing. Also adds corresponding unit tests.