### PR TITLE
Upgrades basic quoted multiline strings

### DIFF
--- a/conda_recipe_manager/parser/_types.py
+++ b/conda_recipe_manager/parser/_types.py
@@ -136,7 +136,11 @@ class Regex:
         r"(\{\{\s*[a-zA-Z0-9_]*.*)\.([a-zA-Z0-9_]*\(.*\)\s*\}\})"
     )
     # Strips empty parenthesis artifacts on functions like `| lower`
-    PRE_PROCESS_JINJA_DOT_FUNCTION_STRIP_EMPTY_PARENTHESIS = re.compile(r"(\|\s*(lower|upper))(\(\))")
+    PRE_PROCESS_JINJA_DOT_FUNCTION_STRIP_EMPTY_PARENTHESIS: Final[re.Pattern[str]] = re.compile(
+        r"(\|\s*(lower|upper))(\(\))"
+    )
+    # Attempts to normalize multiline strings containing quoted escaped newlines.
+    PRE_PROCESS_QUOTED_MULTILINE_STRINGS: Final[re.Pattern[str]] = re.compile(r"(\s*)(.*):\s*['\"](.*)\\n(.*)['\"]")
 
     ## Jinja regular expressions ##
     JINJA_SUB: Final[re.Pattern[str]] = re.compile(r"{{\s*" + _JINJA_VAR_FUNCTION_PATTERN + r"\s*}}")

--- a/conda_recipe_manager/parser/recipe_parser_convert.py
+++ b/conda_recipe_manager/parser/recipe_parser_convert.py
@@ -670,6 +670,9 @@ class RecipeParserConvert(RecipeParser):
         content = Regex.PRE_PROCESS_JINJA_DOT_FUNCTION_IN_SUBSTITUTION.sub(r"\1 | \2", content)
         # Strip any problematic parenthesis that may be left over from the previous operations.
         content = Regex.PRE_PROCESS_JINJA_DOT_FUNCTION_STRIP_EMPTY_PARENTHESIS.sub(r"\1", content)
+        # Attempt to normalize quoted multiline strings into the common `|` syntax.
+        # TODO: Handle multiple escaped newlines (very uncommon)
+        content = Regex.PRE_PROCESS_QUOTED_MULTILINE_STRINGS.sub(r"\1\2: |\1  \3\1  \4", content)
 
         # Convert the old JINJA `environ[""]` variable usage to the new `get.env("")` syntax.
         # NOTE:

--- a/tests/parser/test_recipe_parser_convert.py
+++ b/tests/parser/test_recipe_parser_convert.py
@@ -21,6 +21,8 @@ from tests.file_loading import TEST_FILES_PATH, load_file, load_recipe_convert
         ("simple-recipe_environ.yaml", "pre_processor/pp_simple-recipe_environ.yaml"),
         # Dot-function for pipe equivalent replacement
         ("dot_function_replacement.yaml", "pre_processor/pp_dot_function_replacement.yaml"),
+        # Upgrading multiline quoted strings
+        ("quoted_multiline_str.yaml", "pre_processor/pp_quoted_multiline_str.yaml"),
         # Unchanged file
         ("simple-recipe.yaml", "simple-recipe.yaml"),
     ],

--- a/tests/test_aux_files/pre_processor/pp_quoted_multiline_str.yaml
+++ b/tests/test_aux_files/pre_processor/pp_quoted_multiline_str.yaml
@@ -1,0 +1,31 @@
+{% set name = "quoted_multiline_str" %}
+{% set version = "0.10.8.6" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/script-env-{{ version }}.tar.gz
+
+build:
+  number: 0
+  skip: true  # [py<37]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python
+  run:
+    - python
+
+about:
+  home: https://github.com/python/typeshed
+  summary: Typing stubs for toml
+  description: |
+    Tests handling of
+    multiline quoted strings
+  license: MIT
+  license_file: LICENSE
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://pypi.org/project/types-toml/

--- a/tests/test_aux_files/quoted_multiline_str.yaml
+++ b/tests/test_aux_files/quoted_multiline_str.yaml
@@ -1,0 +1,29 @@
+{% set name = "quoted_multiline_str" %}
+{% set version = "0.10.8.6" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/script-env-{{ version }}.tar.gz
+
+build:
+  number: 0
+  skip: true  # [py<37]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python
+  run:
+    - python
+
+about:
+  home: https://github.com/python/typeshed
+  summary: Typing stubs for toml
+  description: "Tests handling of\nmultiline quoted strings"
+  license: MIT
+  license_file: LICENSE
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://pypi.org/project/types-toml/


### PR DESCRIPTION
A handful of recipes have quoted multiline strings, that the parser does not support:
```yaml
  description: "Tests handling of\nmultiline quoted strings"
```

So the preprocessing phase will now attempt to convert this to a pipe-marked multiline string:
```yaml
  description: |
    Tests handling of
    multiline quoted strings
```

There aren't many recipes that use this format, and even fewer that have multiple newlines in the quoted string. Hence why this is a pre-processor fix.