### PR TITLE
Fixes integration tests from rattler-build 0.18.0 update

### DIFF
--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -33,11 +33,11 @@ jobs:
             convert-success: 0.90
             rattler-success: 0.75
           - test-directory: bioconda_recipes_01
-            convert-success: 0.55
-            rattler-success: 0.35
+            convert-success: 0.85
+            rattler-success: 0.70
           - test-directory: bioconda_recipes_02
-            convert-success: 0.60
-            rattler-success: 0.45
+            convert-success: 0.85
+            rattler-success: 0.75
           - test-directory: bioconda_recipes_03
             convert-success: 0.85
             rattler-success: 0.55

--- a/conda_recipe_manager/parser/_types.py
+++ b/conda_recipe_manager/parser/_types.py
@@ -141,6 +141,9 @@ class Regex:
     )
     # Attempts to normalize multiline strings containing quoted escaped newlines.
     PRE_PROCESS_QUOTED_MULTILINE_STRINGS: Final[re.Pattern[str]] = re.compile(r"(\s*)(.*):\s*['\"](.*)\\n(.*)['\"]")
+    # rattler-build@0.18.0 deprecates `min_pin` and `max_pin`
+    PRE_PROCESS_MIN_PIN_REPLACEMENT: Final[re.Pattern[str]] = re.compile(r"min_pin=")
+    PRE_PROCESS_MAX_PIN_REPLACEMENT: Final[re.Pattern[str]] = re.compile(r"max_pin=")
 
     ## Jinja regular expressions ##
     JINJA_SUB: Final[re.Pattern[str]] = re.compile(r"{{\s*" + _JINJA_VAR_FUNCTION_PATTERN + r"\s*}}")

--- a/conda_recipe_manager/parser/recipe_parser.py
+++ b/conda_recipe_manager/parser/recipe_parser.py
@@ -226,7 +226,9 @@ class RecipeParser:
         if not isinstance(value, PRIMITIVES_TUPLE):
             # Although not technically required by YAML, we add the optional spacing for human readability.
             return RecipeParser(  # pylint: disable=protected-access
-                yaml.dump(value, Dumper=ForceIndentDumper, sort_keys=False)  # type: ignore[misc]
+                # NOTE: `yaml.dump()` defaults to 80 character lines. Longer lines may have newlines unexpectedly
+                #       injected into this value, screwing up the parse-tree.
+                yaml.dump(value, Dumper=ForceIndentDumper, sort_keys=False, width=sys.maxsize)  # type: ignore[misc]
             )._root.children
 
         # Primitives can be safely stringified to generate a parse tree.

--- a/conda_recipe_manager/parser/recipe_parser_convert.py
+++ b/conda_recipe_manager/parser/recipe_parser_convert.py
@@ -676,8 +676,8 @@ class RecipeParserConvert(RecipeParser):
 
         # rattler-build@0.18.0: Introduced checks for deprecated `max_pin` and `min_pin` fields. This replacement
         # addresses the change in numerous JINJA functions that use this nomenclature.
-        content = Regex.PRE_PROCESS_MIN_PIN_REPLACEMENT.sub(r"lower_bound=", content)
-        content = Regex.PRE_PROCESS_MAX_PIN_REPLACEMENT.sub(r"upper_bound=", content)
+        content = Regex.PRE_PROCESS_MIN_PIN_REPLACEMENT.sub("lower_bound=", content)
+        content = Regex.PRE_PROCESS_MAX_PIN_REPLACEMENT.sub("upper_bound=", content)
 
         # Convert the old JINJA `environ[""]` variable usage to the new `get.env("")` syntax.
         # NOTE:

--- a/conda_recipe_manager/parser/recipe_parser_convert.py
+++ b/conda_recipe_manager/parser/recipe_parser_convert.py
@@ -674,6 +674,11 @@ class RecipeParserConvert(RecipeParser):
         # TODO: Handle multiple escaped newlines (very uncommon)
         content = Regex.PRE_PROCESS_QUOTED_MULTILINE_STRINGS.sub(r"\1\2: |\1  \3\1  \4", content)
 
+        # rattler-build@0.18.0: Introduced checks for deprecated `max_pin` and `min_pin` fields. This replacement
+        # addresses the change in numerous JINJA functions that use this nomenclature.
+        content = Regex.PRE_PROCESS_MIN_PIN_REPLACEMENT.sub(r"lower_bound=", content)
+        content = Regex.PRE_PROCESS_MAX_PIN_REPLACEMENT.sub(r"upper_bound=", content)
+
         # Convert the old JINJA `environ[""]` variable usage to the new `get.env("")` syntax.
         # NOTE:
         #   - This is mostly used by Bioconda recipes and R-based-packages in the `license_file` field.

--- a/tests/test_aux_files/v1_format/v1_google-cloud-cpp.yaml
+++ b/tests/test_aux_files/v1_format/v1_google-cloud-cpp.yaml
@@ -93,9 +93,7 @@ outputs:
           - if: unix
             then: test ! -f $PREFIX/lib/cmake/google_cloud_cpp_kms/google_cloud_cpp_kms-config.cmake
           - if: win
-            then:
-              - if exist %LIBRARY_PREFIX%\\lib\\cmake\\google_cloud_cpp_kms\\google_cloud_cpp_kms-config.cmake
-              - exit 1
+            then: if exist %LIBRARY_PREFIX%\\lib\\cmake\\google_cloud_cpp_kms\\google_cloud_cpp_kms-config.cmake exit 1
     script: install-libgoogle-cloud.sh  # [unix]
     script: install-libgoogle-cloud.bat  # [win]
   - package:


### PR DESCRIPTION
[rattler-build@0.18.0](https://github.com/prefix-dev/rattler-build/releases/tag/v0.18.0) introduces a new check for the deprecated `min_pin`/`max_pin` arguments used in a number of JINJA pinning functions.

This simple regex replaces the terms with the new nomenclature, fixing the underlying issue.

In making this simple replacement, however, the integration tests started failing for the `bioconda_recipes_02` data set. Diving deeper uncovered that `yaml.dump()` enforces a strict 80-character line limit by default, causing a number of unexpected issues when converting recipes. Fixing that greatly improved compatibility with all bioconda datasets, as many bioconda recipes exceed 80 characters in length on at least 1 line.