### PR TITLE
Upgrades commonly used selectors

### DIFF
--- a/conda_recipe_manager/parser/_types.py
+++ b/conda_recipe_manager/parser/_types.py
@@ -148,6 +148,10 @@ class Regex:
     ## Selector Replacements ##
     # Replaces Python version expressions with the newer V1 `match()` function
     SELECTOR_PYTHON_VERSION_REPLACEMENT: Final[re.Pattern[str]] = re.compile(r"py\s*(<|>|<=|>=|==|!=)\s*(3|2)([0-9]+)")
+    SELECTOR_PYTHON_VERSION_EQ_REPLACEMENT: Final[re.Pattern[str]] = re.compile(r"py(3|2)([0-9]+)")
+    SELECTOR_PYTHON_VERSION_NE_REPLACEMENT: Final[re.Pattern[str]] = re.compile(r"not py(3|2)([0-9]+)")
+    SELECTOR_PYTHON_VERSION_PY2K_REPLACEMENT: Final[re.Pattern[str]] = re.compile(r"py2k")
+    SELECTOR_PYTHON_VERSION_PY3K_REPLACEMENT: Final[re.Pattern[str]] = re.compile(r"py3k")
 
     ## Jinja regular expressions ##
     JINJA_SUB: Final[re.Pattern[str]] = re.compile(r"{{\s*" + _JINJA_VAR_FUNCTION_PATTERN + r"\s*}}")

--- a/conda_recipe_manager/parser/_types.py
+++ b/conda_recipe_manager/parser/_types.py
@@ -145,6 +145,10 @@ class Regex:
     PRE_PROCESS_MIN_PIN_REPLACEMENT: Final[re.Pattern[str]] = re.compile(r"min_pin=")
     PRE_PROCESS_MAX_PIN_REPLACEMENT: Final[re.Pattern[str]] = re.compile(r"max_pin=")
 
+    ## Selector Replacements ##
+    # Replaces Python version expressions with the newer V1 `match()` function
+    SELECTOR_PYTHON_VERSION_REPLACEMENT: Final[re.Pattern[str]] = re.compile(r"py\s*(<|>|<=|>=|==|!=)\s*(3|2)([0-9]+)")
+
     ## Jinja regular expressions ##
     JINJA_SUB: Final[re.Pattern[str]] = re.compile(r"{{\s*" + _JINJA_VAR_FUNCTION_PATTERN + r"\s*}}")
     JINJA_LINE: Final[re.Pattern[str]] = re.compile(r"({%.*%}|{#.*#})\n")
@@ -158,10 +162,13 @@ class Regex:
     JINJA_FUNCTION_LOWER: Final[re.Pattern[str]] = re.compile(r"\|\s*(lower)")
     JINJA_FUNCTION_UPPER: Final[re.Pattern[str]] = re.compile(r"\|\s*(upper)")
     JINJA_FUNCTION_REPLACE: Final[re.Pattern[str]] = re.compile(r"\|\s*(replace)\((.*)\)")
+    # `match()` is a JINJA function available in the V1 recipe format
+    JINJA_FUNCTION_MATCH: Final[re.Pattern[str]] = re.compile(r"match\(.*,.*\)")
     JINJA_FUNCTIONS_SET: Final[set[re.Pattern[str]]] = {
         JINJA_FUNCTION_LOWER,
         JINJA_FUNCTION_UPPER,
         JINJA_FUNCTION_REPLACE,
+        JINJA_FUNCTION_MATCH,
     }
 
     SELECTOR: Final[re.Pattern[str]] = re.compile(r"\[.*\]")

--- a/conda_recipe_manager/parser/_utils.py
+++ b/conda_recipe_manager/parser/_utils.py
@@ -126,7 +126,9 @@ def quote_special_strings(s: str, multiline_variant: MultilineVariant = Multilin
                 return True
         return False
 
-    if multiline_variant != MultilineVariant.NONE or Regex.JINJA_SUB.match(s):
+    # Do not mess with quotes in multiline strings or strings containing JINJA substitutions or JINJA functions used
+    # without substitution markers (like `match()`)
+    if multiline_variant != MultilineVariant.NONE or Regex.JINJA_SUB.match(s) or Regex.JINJA_FUNCTION_MATCH.search(s):
         return s
 
     # `*` is common enough that we query the set before checking every "startswith" option as a small optimization.

--- a/conda_recipe_manager/parser/recipe_parser_convert.py
+++ b/conda_recipe_manager/parser/recipe_parser_convert.py
@@ -227,7 +227,6 @@ class RecipeParserConvert(RecipeParser):
                 )
 
                 # TODO other common selectors to support:
-                # - py2k, py3k
                 # - GPU variants (see pytorch and llama.cpp feedstocks)
 
                 # For now, if a selector lands on a boolean value, use a ternary statement. Otherwise use the

--- a/tests/parser/test_recipe_parser_convert.py
+++ b/tests/parser/test_recipe_parser_convert.py
@@ -150,6 +150,12 @@ def test_pre_process_recipe_text(input_file: str, expected_file: str) -> None:
             [],
             [],
         ),
+        # Ensures common comparison selectors can be upgraded
+        (
+            "selector-match-upgrades.yaml",
+            [],
+            [],
+        ),
         # TODO complete: The `rust.yaml` test contains many edge cases and selectors that aren't directly supported in
         # the V1 recipe format
         # (

--- a/tests/test_aux_files/selector-match-upgrades.yaml
+++ b/tests/test_aux_files/selector-match-upgrades.yaml
@@ -1,0 +1,42 @@
+{% set name = "selector-match-upgrades" %}
+{% set version = "0.10.8.6" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/script-env-{{ version }}.tar.gz
+  sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
+
+build:
+  # NOTE: `/build/skip` is special and will not be JINJA-escaped.
+  number: 0
+  skip: true  # [py<37]
+  skip1: true  # [not py37]
+  skip2: true  # [py>=27]
+  skip3: true  # [py != 310]
+  skip4: true  # [py2k]
+  skip5: true  # [py3k]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python  # [not py27]
+  run:
+    - python  # [py27]
+    - foo # [py<37]
+    - foo # [not py37]
+    - foo # [py>=27]
+    - foo # [py != 310]
+    - foo # [py2k]
+    - foo # [py3k]
+
+about:
+  home: https://github.com/python/typeshed
+  summary: Typing stubs for toml
+  description: Tests upgrading various selectors that are now replaced by the `match()` function
+  license: MIT
+  license_file: LICENSE
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://pypi.org/project/types-toml/

--- a/tests/test_aux_files/v1_format/v1_boto.yaml
+++ b/tests/test_aux_files/v1_format/v1_boto.yaml
@@ -29,10 +29,10 @@ tests:
         - boto
       pip_check: false
   - script:
-      - if: py2k
+      - if: match(python, ">=2,<3")
         then: asadmin -h
       - s3put -h
-      - if: py2k
+      - if: match(python, ">=2,<3")
         then: taskadmin -h
 
 about:

--- a/tests/test_aux_files/v1_format/v1_git-src.yaml
+++ b/tests/test_aux_files/v1_format/v1_git-src.yaml
@@ -17,8 +17,7 @@ source:
 
 build:
   number: 0
-  skip:
-    - py<37
+  skip: match(python, "<3.7")
   script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:

--- a/tests/test_aux_files/v1_format/v1_huggingface_hub.yaml
+++ b/tests/test_aux_files/v1_format/v1_huggingface_hub.yaml
@@ -14,8 +14,7 @@ source:
 
 build:
   number: 0
-  skip:
-    - py<37
+  skip: match(python, "<3.7")
   script: ${{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   python:
     entry_points:
@@ -31,7 +30,7 @@ requirements:
     - python
     - filelock
     - fsspec
-    - if: py<38
+    - if: match(python, "<3.8")
       then: importlib-metadata
     - packaging >=20.9
     - pyyaml >=5.1

--- a/tests/test_aux_files/v1_format/v1_non_marked_multiline_summary.yaml
+++ b/tests/test_aux_files/v1_format/v1_non_marked_multiline_summary.yaml
@@ -14,8 +14,7 @@ source:
 
 build:
   number: 0
-  skip:
-    - py<37
+  skip: match(python, "<3.7")
   script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:

--- a/tests/test_aux_files/v1_format/v1_script-env.yaml
+++ b/tests/test_aux_files/v1_format/v1_script-env.yaml
@@ -14,8 +14,7 @@ source:
 
 build:
   number: 0
-  skip:
-    - py<37
+  skip: match(python, "<3.7")
   script:
     env:
       FOO: BAR

--- a/tests/test_aux_files/v1_format/v1_selector-match-upgrades.yaml
+++ b/tests/test_aux_files/v1_format/v1_selector-match-upgrades.yaml
@@ -1,0 +1,53 @@
+schema_version: 1
+
+context:
+  name: selector-match-upgrades
+  version: 0.10.8.6
+
+package:
+  name: ${{ name|lower }}
+  version: ${{ version }}
+
+source:
+  url: https://pypi.io/packages/source/${{ name[0] }}/${{ name }}/script-env-${{ version }}.tar.gz
+  sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
+
+build:
+  # NOTE: `/build/skip` is special and will not be JINJA-escaped.
+  number: 0
+  skip: match(python, "<3.7")
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  skip1: ${{ true if not match(python, "==3.7") }}
+  skip2: ${{ true if match(python, ">=2.7") }}
+  skip3: ${{ true if match(python, "!=3.10") }}
+  skip4: ${{ true if match(python, ">=2,<3") }}
+  skip5: ${{ true if match(python, ">=3,<4") }}
+
+requirements:
+  host:
+    - if: not match(python, "==2.7")
+      then: python
+  run:
+    - if: match(python, "==2.7")
+      then: python
+    - if: match(python, "<3.7")
+      then: foo
+    - if: not match(python, "==3.7")
+      then: foo
+    - if: match(python, ">=2.7")
+      then: foo
+    - if: match(python, "!=3.10")
+      then: foo
+    - if: match(python, ">=2,<3")
+      then: foo
+    - if: match(python, ">=3,<4")
+      then: foo
+
+about:
+  summary: Typing stubs for toml
+  description: Tests upgrading various selectors that are now replaced by the `match()` function
+  license: MIT
+  license_file: LICENSE
+  homepage: https://github.com/python/typeshed
+  repository: https://github.com/python/typeshed
+  documentation: https://pypi.org/project/types-toml/

--- a/tests/test_aux_files/v1_format/v1_simple-recipe.yaml
+++ b/tests/test_aux_files/v1_format/v1_simple-recipe.yaml
@@ -11,8 +11,7 @@ package:
 
 build:
   number: 0
-  skip:
-    - py<37
+  skip: match(python, "<3.7")
   is_true: true
 
 requirements:

--- a/tests/test_aux_files/v1_format/v1_types-toml.yaml
+++ b/tests/test_aux_files/v1_format/v1_types-toml.yaml
@@ -14,8 +14,7 @@ source:
 
 build:
   number: 0
-  skip:
-    - py<37
+  skip: match(python, "<3.7")
   script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:


### PR DESCRIPTION
This discovery came out of developing #77 and some discussions held on the public Conda Build Tools Element channel.

The commonly used `py<37` selector expression is no longer supported in the new recipe format (see https://github.com/conda/ceps/pull/71 and https://prefix-dev.github.io/rattler-build/latest/selectors/#selector-evaluation).

These selector aliases/expressions have been superseded by the new `match()` function in the V1 recipe format.

This is the first issue we have found that occurs in when performing a full build with `rattler-build` BUT does not appear in a dry-run build. There are likely many more such issues to be discovered.

This PR also stores `/build/skip` expressions as a single value instead of a list. I believe this was a temporary workaround to a schema issue that has since been resolved in `rattler-build`.