### PR TITLE
Adds some basic support for editing V1 recipe files

### DIFF
--- a/conda_recipe_manager/parser/_types.py
+++ b/conda_recipe_manager/parser/_types.py
@@ -154,12 +154,16 @@ class Regex:
     SELECTOR_PYTHON_VERSION_PY3K_REPLACEMENT: Final[re.Pattern[str]] = re.compile(r"py3k")
 
     ## Jinja regular expressions ##
-    JINJA_SUB: Final[re.Pattern[str]] = re.compile(r"{{\s*" + _JINJA_VAR_FUNCTION_PATTERN + r"\s*}}")
-    JINJA_LINE: Final[re.Pattern[str]] = re.compile(r"({%.*%}|{#.*#})\n")
-    JINJA_SET_LINE: Final[re.Pattern[str]] = re.compile(r"{%\s*set\s*" + _JINJA_VAR_FUNCTION_PATTERN + r"\s*=.*%}\s*\n")
+    JINJA_V0_SUB: Final[re.Pattern[str]] = re.compile(r"{{\s*" + _JINJA_VAR_FUNCTION_PATTERN + r"\s*}}")
+    JINJA_V0_LINE: Final[re.Pattern[str]] = re.compile(r"({%.*%}|{#.*#})\n")
+    JINJA_V0_SET_LINE: Final[re.Pattern[str]] = re.compile(
+        r"{%\s*set\s*" + _JINJA_VAR_FUNCTION_PATTERN + r"\s*=.*%}\s*\n"
+    )
     # Useful for replacing the older `{{` JINJA substitution with the newer `${{` WITHOUT accidentally doubling-up the
     # newer syntax when multiple replacements are possible.
     JINJA_REPLACE_V0_STARTING_MARKER: Final[re.Pattern[str]] = re.compile(r"(?<!\$)\{\{")
+
+    JINJA_V1_SUB: Final[re.Pattern[str]] = re.compile(r"\${{\s*" + _JINJA_VAR_FUNCTION_PATTERN + r"\s*}}")
 
     # All recognized JINJA functions are kept in a set for the convenience of trying to match against all of them.
     # Group 1 contains the function name, Group 2 contains the arguments, if any.

--- a/conda_recipe_manager/parser/_utils.py
+++ b/conda_recipe_manager/parser/_utils.py
@@ -128,7 +128,11 @@ def quote_special_strings(s: str, multiline_variant: MultilineVariant = Multilin
 
     # Do not mess with quotes in multiline strings or strings containing JINJA substitutions or JINJA functions used
     # without substitution markers (like `match()`)
-    if multiline_variant != MultilineVariant.NONE or Regex.JINJA_SUB.match(s) or Regex.JINJA_FUNCTION_MATCH.search(s):
+    if (
+        multiline_variant != MultilineVariant.NONE
+        or Regex.JINJA_V0_SUB.match(s)
+        or Regex.JINJA_FUNCTION_MATCH.search(s)
+    ):
         return s
 
     # `*` is common enough that we query the set before checking every "startswith" option as a small optimization.

--- a/conda_recipe_manager/parser/enums.py
+++ b/conda_recipe_manager/parser/enums.py
@@ -5,7 +5,17 @@ Description:    Provides enumerated types used by the parser.
 
 from __future__ import annotations
 
-from enum import Enum
+from enum import Enum, IntEnum
+
+
+class SchemaVersion(IntEnum):
+    """
+    Recipe `schema_version` enumeration. The Pre-CEP-13 "schema" is designated as "Version 0" and does not require
+    a `schema_version` field in the recipe file.
+    """
+
+    V0 = 0  # Pre-CEP-13, effectively defined by conda-build
+    V1 = 1  # CEP-13+
 
 
 class SelectorConflictMode(Enum):

--- a/conda_recipe_manager/parser/recipe_parser.py
+++ b/conda_recipe_manager/parser/recipe_parser.py
@@ -491,6 +491,13 @@ class RecipeParser:
         """
         return self._is_modified
 
+    def get_schema_version(self) -> SchemaVersion:
+        """
+        Returns which version of the schema this recipe uses. Useful for preventing illegal operations.
+        :returns: Schema Version of the recipe file.
+        """
+        return self._schema_version
+
     def has_unsupported_statements(self) -> bool:
         """
         Runs a series of checks against the original recipe file.

--- a/conda_recipe_manager/parser/recipe_parser.py
+++ b/conda_recipe_manager/parser/recipe_parser.py
@@ -53,7 +53,13 @@ from conda_recipe_manager.parser._utils import (
 )
 from conda_recipe_manager.parser.enums import SelectorConflictMode
 from conda_recipe_manager.parser.exceptions import JsonPatchValidationException
-from conda_recipe_manager.parser.types import JSON_PATCH_SCHEMA, TAB_AS_SPACES, TAB_SPACE_COUNT, MultilineVariant
+from conda_recipe_manager.parser.types import (
+    JSON_PATCH_SCHEMA,
+    TAB_AS_SPACES,
+    TAB_SPACE_COUNT,
+    MultilineVariant,
+    SchemaVersion,
+)
 from conda_recipe_manager.types import PRIMITIVES_TUPLE, JsonPatchType, JsonType, Primitives, SentinelType
 
 
@@ -381,6 +387,12 @@ class RecipeParser:
             parent.children.append(new_node)
             # Update the last node for the next line interpretation
             last_node = new_node
+
+        # Auto-detect and deserialize the version of the recipe schema. This will change how the class behaves.
+        self._schema_version = SchemaVersion.V0
+        schema_version = cast(SchemaVersion | int, self.get_value("/schema_version", SchemaVersion.V0))
+        if isinstance(schema_version, int) and schema_version == 1:
+            self._schema_version = SchemaVersion.V1
 
         # Now that the tree is built, construct a selector look-up table that tracks all the nodes that use a particular
         # selector. This will make it easier to.

--- a/conda_recipe_manager/parser/recipe_parser.py
+++ b/conda_recipe_manager/parser/recipe_parser.py
@@ -51,15 +51,9 @@ from conda_recipe_manager.parser._utils import (
     stringify_yaml,
     substitute_markers,
 )
-from conda_recipe_manager.parser.enums import SelectorConflictMode
+from conda_recipe_manager.parser.enums import SchemaVersion, SelectorConflictMode
 from conda_recipe_manager.parser.exceptions import JsonPatchValidationException
-from conda_recipe_manager.parser.types import (
-    JSON_PATCH_SCHEMA,
-    TAB_AS_SPACES,
-    TAB_SPACE_COUNT,
-    MultilineVariant,
-    SchemaVersion,
-)
+from conda_recipe_manager.parser.types import JSON_PATCH_SCHEMA, TAB_AS_SPACES, TAB_SPACE_COUNT, MultilineVariant
 from conda_recipe_manager.types import PRIMITIVES_TUPLE, JsonPatchType, JsonType, Primitives, SentinelType
 
 

--- a/conda_recipe_manager/parser/recipe_parser.py
+++ b/conda_recipe_manager/parser/recipe_parser.py
@@ -440,6 +440,7 @@ class RecipeParser:
         tree_lines: list[str] = []
         RecipeParser._str_tree_recurse(self._root, 0, tree_lines)
         s += "RecipeParser Instance\n"
+        s += f"- Schema Version: {self._schema_version}\n"
         s += "- Variables Table:\n"
         s += json.dumps(self._vars_tbl, indent=TAB_AS_SPACES) + "\n"
         s += "- Selectors Table:\n"

--- a/conda_recipe_manager/parser/recipe_parser.py
+++ b/conda_recipe_manager/parser/recipe_parser.py
@@ -480,6 +480,8 @@ class RecipeParser:
         """
         if not isinstance(other, RecipeParser):
             raise TypeError
+        if self._schema_version != other._schema_version:
+            return False
         return self.render() == other.render()
 
     def is_modified(self) -> bool:

--- a/conda_recipe_manager/parser/recipe_parser_convert.py
+++ b/conda_recipe_manager/parser/recipe_parser_convert.py
@@ -172,7 +172,7 @@ class RecipeParserConvert(RecipeParser):
         # Swap all JINJA to use the new `${{ }}` format. A `set` is used as `str.replace()` will replace all instances
         # and a value containing multiple variables could be visited multiple times, causing multiple `${{}}`
         # encapsulations.
-        jinja_sub_locations: Final[set[str]] = set(self._v1_recipe.search(Regex.JINJA_SUB))
+        jinja_sub_locations: Final[set[str]] = set(self._v1_recipe.search(Regex.JINJA_V0_SUB))
         for path in jinja_sub_locations:
             value = self._v1_recipe.get_value(path)
             # Values that match the regex should only be strings. This prevents crashes that should not occur.

--- a/conda_recipe_manager/parser/recipe_parser_convert.py
+++ b/conda_recipe_manager/parser/recipe_parser_convert.py
@@ -810,5 +810,8 @@ class RecipeParserConvert(RecipeParser):
 
         # Override the schema value as the recipe conversion is now complete.
         self._v1_recipe._schema_version = SchemaVersion.V1  # pylint: disable=protected-access
+        # Update the variable table
+        self._v1_recipe._init_vars_tbl()  # pylint: disable=protected-access
+        # TODO update selector table when V1 selectors are supported!
 
         return self._v1_recipe.render(), self._msg_tbl, str(self._v1_recipe)

--- a/conda_recipe_manager/parser/recipe_parser_convert.py
+++ b/conda_recipe_manager/parser/recipe_parser_convert.py
@@ -26,8 +26,9 @@ from conda_recipe_manager.parser._utils import (
     stack_path_to_str,
     str_to_stack_path,
 )
+from conda_recipe_manager.parser.enums import SchemaVersion
 from conda_recipe_manager.parser.recipe_parser import RecipeParser
-from conda_recipe_manager.parser.types import CURRENT_RECIPE_SCHEMA_FORMAT, MessageCategory, MessageTable, SchemaVersion
+from conda_recipe_manager.parser.types import CURRENT_RECIPE_SCHEMA_FORMAT, MessageCategory, MessageTable
 from conda_recipe_manager.types import JsonPatchType, JsonType, Primitives, SentinelType
 
 

--- a/conda_recipe_manager/parser/recipe_parser_convert.py
+++ b/conda_recipe_manager/parser/recipe_parser_convert.py
@@ -27,7 +27,7 @@ from conda_recipe_manager.parser._utils import (
     str_to_stack_path,
 )
 from conda_recipe_manager.parser.recipe_parser import RecipeParser
-from conda_recipe_manager.parser.types import CURRENT_RECIPE_SCHEMA_FORMAT, MessageCategory, MessageTable
+from conda_recipe_manager.parser.types import CURRENT_RECIPE_SCHEMA_FORMAT, MessageCategory, MessageTable, SchemaVersion
 from conda_recipe_manager.types import JsonPatchType, JsonType, Primitives, SentinelType
 
 
@@ -806,5 +806,8 @@ class RecipeParserConvert(RecipeParser):
         # Sort the top-level keys to a "canonical" ordering. This should make previous patch operations look more
         # "sensible" to a human reader.
         self._sort_subtree_keys("/", TOP_LEVEL_KEY_SORT_ORDER)
+
+        # Override the schema value as the recipe conversion is now complete.
+        self._v1_recipe._schema_version = SchemaVersion.V1  # pylint: disable=protected-access
 
         return self._v1_recipe.render(), self._msg_tbl, str(self._v1_recipe)

--- a/conda_recipe_manager/parser/types.py
+++ b/conda_recipe_manager/parser/types.py
@@ -5,7 +5,7 @@ Description:    Provides public types, type aliases, constants, and small classe
 
 from __future__ import annotations
 
-from enum import StrEnum, auto
+from enum import IntEnum, StrEnum, auto
 from typing import Final
 
 from conda_recipe_manager.types import Primitives, SchemaType
@@ -18,9 +18,20 @@ NodeValue = Primitives | list[str]
 
 #### Constants ####
 
+
+class SchemaVersion(IntEnum):
+    """
+    Recipe `schema_version` enumeration. The Pre-CEP-13 "schema" is designated as "Version 0" and does not require
+    a `schema_version` field in the recipe file.
+    """
+
+    V0 = 0  # Pre-CEP-13, effectively defined by conda-build
+    V1 = 1  # CEP-13+
+
+
 # The "new" recipe format introduces the concept of a schema version. Presumably the "old" recipe format would be
 # considered "0". When converting to the V1 format, we'll use this constant value.
-CURRENT_RECIPE_SCHEMA_FORMAT: Final[int] = 1
+CURRENT_RECIPE_SCHEMA_FORMAT: Final[int] = SchemaVersion.V1.value
 
 # Indicates how many spaces are in a level of indentation
 TAB_SPACE_COUNT: Final[int] = 2

--- a/conda_recipe_manager/parser/types.py
+++ b/conda_recipe_manager/parser/types.py
@@ -5,9 +5,10 @@ Description:    Provides public types, type aliases, constants, and small classe
 
 from __future__ import annotations
 
-from enum import IntEnum, StrEnum, auto
+from enum import StrEnum, auto
 from typing import Final
 
+from conda_recipe_manager.parser.enums import SchemaVersion
 from conda_recipe_manager.types import Primitives, SchemaType
 
 #### Types ####
@@ -17,17 +18,6 @@ NodeValue = Primitives | list[str]
 
 
 #### Constants ####
-
-
-class SchemaVersion(IntEnum):
-    """
-    Recipe `schema_version` enumeration. The Pre-CEP-13 "schema" is designated as "Version 0" and does not require
-    a `schema_version` field in the recipe file.
-    """
-
-    V0 = 0  # Pre-CEP-13, effectively defined by conda-build
-    V1 = 1  # CEP-13+
-
 
 # The "new" recipe format introduces the concept of a schema version. Presumably the "old" recipe format would be
 # considered "0". When converting to the V1 format, we'll use this constant value.

--- a/tests/commands/test_convert.py
+++ b/tests/commands/test_convert.py
@@ -6,6 +6,7 @@ Description:    Tests the `convert` CLI
 from click.testing import CliRunner
 
 from conda_recipe_manager.commands.convert import convert
+from tests.file_loading import TEST_FILES_PATH, load_file
 
 
 def test_usage() -> None:
@@ -21,3 +22,25 @@ def test_usage() -> None:
     result = runner.invoke(convert, ["--help"])
     assert result.exit_code == 0
     assert result.output.startswith("Usage:")
+
+
+def test_only_allow_v0_recipes() -> None:
+    """
+    Ensures the user gets an error when a V1 recipe is provided to the conversion script.
+    """
+    runner = CliRunner()
+    result = runner.invoke(convert, [f"{TEST_FILES_PATH}/v1_format/v1_simple-recipe.yaml"])
+    assert result.exit_code != 0
+    assert result.output.startswith("ILLEGAL OPERATION:")
+
+
+def test_convert_single_file() -> None:
+    """
+    Ensures the user gets an error when a V1 recipe is provided to the conversion script.
+    """
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(convert, [f"{TEST_FILES_PATH}/simple-recipe.yaml"])
+    # This recipe has warnings
+    assert result.exit_code == 100
+    # `crm convert` prints an additional newline
+    assert result.stdout == load_file(f"{TEST_FILES_PATH}/v1_format/v1_simple-recipe.yaml") + "\n"

--- a/tests/parser/test_recipe_parser.py
+++ b/tests/parser/test_recipe_parser.py
@@ -61,8 +61,8 @@ def test_construction(file: str, schema_version: SchemaVersion) -> None:
         "name": "types-toml",
         "version": "0.10.8.6",
     }
-    assert parser._schema_version == schema_version  # pylint: disable=protected-access
-    assert not parser._is_modified  # pylint: disable=protected-access
+    assert parser.get_schema_version() == schema_version
+    assert not parser.is_modified()
     # TODO assert on selectors table
 
     # TODO assert on tree structure
@@ -161,6 +161,7 @@ def test_round_trip(file: str) -> None:
 @pytest.mark.parametrize(
     "file,substitute,expected",
     [
+        # V0 Recipes
         (
             "simple-recipe.yaml",
             False,
@@ -292,6 +293,7 @@ def test_round_trip(file: str) -> None:
 def test_render_to_object(file: str, substitute: bool, expected: JsonType) -> None:
     """
     Tests rendering a recipe to an object format.
+    TODO: Does not work with V1 recipes; if/then selectors crash with KeyError
     :param file: File to load and test against
     :param substitute: True to run the function with JINJA substitutions on, False for off
     :param expected: Expected value to return

--- a/tests/parser/test_recipe_parser.py
+++ b/tests/parser/test_recipe_parser.py
@@ -51,6 +51,8 @@ QUICK_FOX_SUB_CARROT_MINUS: Final[str] = "The quick brown tiger\njumped over the
 def test_construction(file: str, schema_version: SchemaVersion) -> None:
     """
     Tests the construction of a recipe parser instance with a simple, common example file.
+    :param file: Recipe file to test with
+    :param schema_version: Schema version to match
     """
     types_toml = load_file(f"{TEST_FILES_PATH}/{file}")
     parser = RecipeParser(types_toml)
@@ -67,25 +69,44 @@ def test_construction(file: str, schema_version: SchemaVersion) -> None:
     # assert parser._root == TODO
 
 
-def test_str() -> None:
+@pytest.mark.parametrize(
+    "file,out_file",
+    [
+        ("simple-recipe.yaml", "simple-recipe_to_str.out"),
+        ("v1_format/v1_simple-recipe.yaml", "v1_format/v1_simple-recipe_to_str.out"),
+    ],
+)
+def test_str(file: str, out_file: str) -> None:
     """
-    Tests string casting
+    Tests rendering to a debug string
+    :param file: Recipe file to test with
+    :param out_file: Output string to match
     """
-    parser = load_recipe("simple-recipe.yaml")
-    assert str(parser) == load_file(f"{TEST_FILES_PATH}/simple-recipe_to_str.out")
+    parser = load_recipe(file)
+    assert str(parser) == load_file(f"{TEST_FILES_PATH}/{out_file}")
     # Regression test: Run a function a second time to ensure that `SelectorInfo::__str__()` doesn't accidentally purge
     # the underlying stack when the string is being rendered.
-    assert str(parser) == load_file(f"{TEST_FILES_PATH}/simple-recipe_to_str.out")
+    assert str(parser) == load_file(f"{TEST_FILES_PATH}/{out_file}")
     assert not parser.is_modified()
 
 
-def test_eq() -> None:
+@pytest.mark.parametrize(
+    "file,other_file",
+    [
+        ("simple-recipe.yaml", "types-toml.yaml"),
+        ("v1_format/v1_simple-recipe.yaml", "v1_format/v1_types-toml.yaml"),
+        ("v1_format/v1_simple-recipe.yaml", "simple-recipe.yaml"),
+    ],
+)
+def test_eq(file: str, other_file: str) -> None:
     """
     Tests equivalency function
+    :param file: Recipe file to test with
+    :param other_file: "Other" recipe file to check against
     """
-    parser0 = load_recipe("simple-recipe.yaml")
-    parser1 = load_recipe("simple-recipe.yaml")
-    parser2 = load_recipe("types-toml.yaml")
+    parser0 = load_recipe(file)
+    parser1 = load_recipe(file)
+    parser2 = load_recipe(other_file)
     assert parser0 == parser1
     assert parser0 != parser2
     assert not parser0.is_modified()
@@ -93,7 +114,6 @@ def test_eq() -> None:
     assert not parser2.is_modified()
 
 
-@pytest.mark.skip(reason="To be re-enable when PAT-46 is fixed")
 def test_loading_obj_in_list() -> None:
     """
     Regression test: at one point, the parser would crash loading this file, containing an object in a list.

--- a/tests/test_aux_files/simple-recipe_to_str.out
+++ b/tests/test_aux_files/simple-recipe_to_str.out
@@ -1,5 +1,6 @@
 --------------------
 RecipeParser Instance
+- Schema Version: 0
 - Variables Table:
 {
   "zz_non_alpha_first": 42,

--- a/tests/test_aux_files/v1_format/v1_simple-recipe_to_str.out
+++ b/tests/test_aux_files/v1_format/v1_simple-recipe_to_str.out
@@ -1,0 +1,82 @@
+--------------------
+RecipeParser Instance
+- Schema Version: 1
+- Variables Table:
+{
+  "zz_non_alpha_first": 42,
+  "name": "types-toml",
+  "version": "0.10.8.6"
+}
+- Selectors Table:
+  [unix and win]
+    - empty_field2 -> /requirements/empty_field2
+- is_modified?: False
+- Tree:
+/
+  |- <Comment: # Comment above a top-level structure>
+  |- schema_version
+    |- 1
+  |- context
+    |- zz_non_alpha_first
+      |- 42
+    |- name
+      |- types-toml
+    |- version
+      |- 0.10.8.6
+  |- package
+    |- name
+      |- ${{ name|lower }}
+  |- build
+    |- number
+      |- 0
+    |- skip
+      |- match(python, "<3.7")
+    |- is_true
+      |- True
+  |- requirements
+    |- empty_field1
+    |- host
+      |- <Collection Node>
+        |- if
+          |- unix
+        |- then
+          |- setuptools
+      |- <Collection Node>
+        |- if
+          |- unix
+        |- then
+          |- fakereq
+    |- empty_field2
+    |- run
+      |- python
+    |- empty_field3
+  |- about
+    |- summary
+      |- This is a small recipe for testing
+    |- description
+      |- ["This is a PEP '561 type stub package for the toml package.", 'It can be used by type-checking tools like mypy, pyright,', 'pytype, PyCharm, etc. to check code that uses toml.']
+    |- license
+      |- Apache-2.0 AND MIT
+  |- multi_level
+    |- list_1
+      |- foo
+      |- <Comment: # Ensure a comment in a list is supported>
+      |- bar
+    |- list_2
+      |- cat
+      |- bat
+      |- mat
+    |- list_3
+      |- ls
+      |- sl
+      |- cowsay
+  |- test_var_usage
+    |- foo
+      |- ${{ version }}
+    |- bar
+      |- baz
+      |- ${{ zz_non_alpha_first }}
+      |- blah
+      |- This ${{ name }} is silly
+      |- last
+--------------------


### PR DESCRIPTION
It has occurred to me that it shouldn't take a lot of work to make the recipe parser capable of editing both V0 and V1 recipe files. You can already make some modifications to V1 recipe files, but this is untested and there will be bugs.

This is the first PR of many that will allow us to edit both V0 and V1 recipes programmatically. The parser is now able to detect which format of a recipe it has been given. Using that knowledge, it will branch on logic that is version specific.

To start, this PR fixes logic around JINJA variable management and starts adding unit test coverage for V1 recipes.

This unit test coverage is not extensive, but I wanted to break this work into multiple PRs before it got too big.