### PR TITLE
Fixes pylint compatibility issues

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,16 +2,13 @@
 #   pre-commit run --all-files
 # Update this file:
 #   pre-commit autoupdate
-# This prevents `pre-commit` from using a newer version of Python, which may cause `pylint` to emit extra errors.
-default_language_version:
-    python: python3.11
 exclude: |
   (?x)^(
     .*/versioneer\.py|.*/_version\.py|.*/.*\.svg|tests/test_aux_files/.*|recipe/meta.yaml
   )$
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.5.0
+  rev: v4.6.0
   hooks:
   - id: check-added-large-files
     exclude_types: ["json", "yaml", "pdf"]
@@ -28,7 +25,7 @@ repos:
   - id: mixed-line-ending
   - id: trailing-whitespace
 - repo: https://github.com/python-jsonschema/check-jsonschema
-  rev: 0.28.0
+  rev: 0.29.1
   hooks:
   - id: check-github-actions
   - id: check-github-workflows
@@ -42,12 +39,12 @@ repos:
   - id: isort
     args: ["--profile", "black", --line-length=120]
 - repo: https://github.com/psf/black
-  rev: 23.12.1
+  rev: 24.4.2
   hooks:
   - id: black
     args: [--line-length=120]
 - repo: https://github.com/PyCQA/pylint
-  rev: v3.1.0
+  rev: v3.2.2
   hooks:
   - id: pylint
     args: ["--rcfile=.pylintrc"]

--- a/conda_recipe_manager/parser/recipe_parser.py
+++ b/conda_recipe_manager/parser/recipe_parser.py
@@ -1039,7 +1039,7 @@ class RecipeParser:
         # If the comment is not a selector, put the selector first, then append the comment.
         else:
             # Strip the existing comment of it's leading `#` symbol
-            comment = f"# {selector} {node.comment.replace('#', '', 1).strip()}"
+            comment = f"# {selector} " + node.comment.replace("#", "", 1).strip()
 
         node.comment = comment
         # Some lines of YAML correspond to multiple nodes. For consistency, we need to ensure that comments are

--- a/conda_recipe_manager/parser/types.py
+++ b/conda_recipe_manager/parser/types.py
@@ -181,10 +181,10 @@ class MessageTable:
             return f"{s}s"
 
         num_errors: Final[int] = 0 if MessageCategory.ERROR not in self._tbl else len(self._tbl[MessageCategory.ERROR])
-        errors: Final[str] = f"{num_errors} {_pluralize(num_errors, 'error')}"
+        errors: Final[str] = f"{num_errors} " + _pluralize(num_errors, "error")
         num_warnings: Final[int] = (
             0 if MessageCategory.WARNING not in self._tbl else len(self._tbl[MessageCategory.WARNING])
         )
-        warnings: Final[str] = f"{num_warnings} {_pluralize(num_warnings, 'warning')}"
+        warnings: Final[str] = f"{num_warnings} " + _pluralize(num_warnings, "warning")
 
         return f"{errors} and {warnings} were found."

--- a/conda_recipe_manager/types.py
+++ b/conda_recipe_manager/types.py
@@ -5,7 +5,8 @@ Description:    Provides public types, type aliases, constants, and small classe
 
 from __future__ import annotations
 
-from typing import Final, Hashable, TypeVar, Union
+from collections.abc import Hashable
+from typing import Final, TypeVar, Union
 
 # Base types that can store value
 Primitives = Union[str, int, float, bool, None]

--- a/environment.yaml
+++ b/environment.yaml
@@ -11,7 +11,8 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-xdist
-  - conda-forge::pylint ==3.1.0  # Match version with .pre-commit-config.yaml
+  # Match version with .pre-commit-config.yaml to ensure consistent rules with `make lint`.
+  - conda-forge::pylint ==3.2.2
   - pip
   - click >=8.1.7
   - conda


### PR DESCRIPTION
- Fixes pylint rule changes for Python 3.12. These fixes should be backwards compatible to 3.11 as well.
- Removes strict Python 3.11 requirement in pre-commit to prevent future confusion
- Updates various pre-commit plugins
- For more context, see here: https://github.com/pylint-dev/pylint/pull/9152