### PR TITLE
Minor Quality of Life improvements

### DIFF
--- a/conda_recipe_manager/commands/convert.py
+++ b/conda_recipe_manager/commands/convert.py
@@ -17,10 +17,15 @@ from typing import Final, Optional
 import click
 
 from conda_recipe_manager.commands.utils.print import print_err, print_messages, print_out
-from conda_recipe_manager.commands.utils.types import V0_FORMAT_RECIPE_FILE_NAME, V1_FORMAT_RECIPE_FILE_NAME, ExitCode
+from conda_recipe_manager.commands.utils.types import ExitCode
 from conda_recipe_manager.parser.enums import SchemaVersion
 from conda_recipe_manager.parser.recipe_parser_convert import RecipeParserConvert
-from conda_recipe_manager.parser.types import MessageCategory, MessageTable
+from conda_recipe_manager.parser.types import (
+    V0_FORMAT_RECIPE_FILE_NAME,
+    V1_FORMAT_RECIPE_FILE_NAME,
+    MessageCategory,
+    MessageTable,
+)
 
 # When performing a bulk operation, overall "success" is indicated by the % of recipe files that were converted
 # "successfully"

--- a/conda_recipe_manager/commands/convert.py
+++ b/conda_recipe_manager/commands/convert.py
@@ -11,44 +11,20 @@ import os
 import sys
 import time
 from dataclasses import dataclass
-from enum import IntEnum
 from pathlib import Path
 from typing import Final, Optional
 
 import click
 
 from conda_recipe_manager.commands.utils.print import print_err, print_messages, print_out
+from conda_recipe_manager.commands.utils.types import V0_FORMAT_RECIPE_FILE_NAME, V1_FORMAT_RECIPE_FILE_NAME, ExitCode
 from conda_recipe_manager.parser.enums import SchemaVersion
 from conda_recipe_manager.parser.recipe_parser_convert import RecipeParserConvert
 from conda_recipe_manager.parser.types import MessageCategory, MessageTable
 
-# Pre-CEP-13 name of the recipe file
-OLD_FORMAT_RECIPE_FILE_NAME: Final[str] = "meta.yaml"
-# Required file name for the recipe, specified in CEP-13
-V1_FORMAT_RECIPE_FILE_NAME: Final[str] = "recipe.yaml"
 # When performing a bulk operation, overall "success" is indicated by the % of recipe files that were converted
 # "successfully"
 DEFAULT_BULK_SUCCESS_PASS_THRESHOLD: Final[float] = 0.80
-
-
-class ExitCode(IntEnum):
-    """
-    Error codes to return upon script completion
-    """
-
-    SUCCESS = 0
-    CLICK_ERROR = 1  # Controlled by the `click` library
-    CLICK_USAGE = 2  # Controlled by the `click` library
-    # In bulk operation mode, this indicates that the % success threshold was not met
-    MISSED_SUCCESS_THRESHOLD = 42
-    # Errors are roughly ordered by increasing severity
-    RENDER_WARNINGS = 100
-    RENDER_ERRORS = 101
-    PARSE_EXCEPTION = 102
-    RENDER_EXCEPTION = 103
-    READ_EXCEPTION = 104
-    PRE_PROCESS_EXCEPTION = 105
-    ILLEGAL_OPERATION = 106
 
 
 @dataclass
@@ -218,7 +194,7 @@ def _get_files_list(path: Path) -> list[Path]:
     files: list[Path] = []
     # Establish which mode of operation we are in, based on the path passed-in
     if path.is_dir():
-        for file_path in path.rglob(OLD_FORMAT_RECIPE_FILE_NAME):
+        for file_path in path.rglob(V0_FORMAT_RECIPE_FILE_NAME):
             files.append(file_path)
         if not files:
             print_err("Could not find any recipe files in this directory.")

--- a/conda_recipe_manager/commands/convert.py
+++ b/conda_recipe_manager/commands/convert.py
@@ -20,12 +20,8 @@ from conda_recipe_manager.commands.utils.print import print_err, print_messages,
 from conda_recipe_manager.commands.utils.types import ExitCode
 from conda_recipe_manager.parser.enums import SchemaVersion
 from conda_recipe_manager.parser.recipe_parser_convert import RecipeParserConvert
-from conda_recipe_manager.parser.types import (
-    V0_FORMAT_RECIPE_FILE_NAME,
-    V1_FORMAT_RECIPE_FILE_NAME,
-    MessageCategory,
-    MessageTable,
-)
+from conda_recipe_manager.parser.types import V0_FORMAT_RECIPE_FILE_NAME, V1_FORMAT_RECIPE_FILE_NAME
+from conda_recipe_manager.types import MessageCategory, MessageTable
 
 # When performing a bulk operation, overall "success" is indicated by the % of recipe files that were converted
 # "successfully"

--- a/conda_recipe_manager/commands/rattler_bulk_build.py
+++ b/conda_recipe_manager/commands/rattler_bulk_build.py
@@ -115,7 +115,7 @@ def create_debug_file(debug_log: Path, results: dict[str, BuildResult], error_hi
         },
     ),
 )
-@click.argument("path", type=click.Path(exists=True, path_type=Path))  # type: ignore[misc]
+@click.argument("path", type=click.Path(exists=True, path_type=Path, file_okay=False))  # type: ignore[misc]
 @click.option(
     "--min-success-rate",
     "-m",

--- a/conda_recipe_manager/commands/rattler_bulk_build.py
+++ b/conda_recipe_manager/commands/rattler_bulk_build.py
@@ -19,23 +19,14 @@ from typing import Final, Optional, cast
 import click
 
 from conda_recipe_manager.commands.utils.print import print_err
+from conda_recipe_manager.commands.utils.types import V1_FORMAT_RECIPE_FILE_NAME, ExitCode
 
-# Required file name for the recipe, specified in CEP-13
-V1_FORMAT_RECIPE_FILE_NAME: Final[str] = "recipe.yaml"
 # When performing a bulk operation, overall "success" is indicated by the % of recipe files that were built
 # "successfully"
 DEFAULT_BULK_SUCCESS_PASS_THRESHOLD: Final[float] = 0.80
 RATTLER_ERROR_REGEX = re.compile(r"Error:\s+.*")
 # Timeout to halt operation
 DEFAULT_RATTLER_BUILD_TIMEOUT: Final[int] = 120
-
-
-## Error codes (NOTE: there may be overlap with rattler-build) ##
-SUCCESS: Final[int] = 0
-NO_FILES_FOUND: Final[int] = 1
-# In bulk operation mode, this indicates that the % success threshold was not met
-MISSED_SUCCESS_THRESHOLD: Final[int] = 42
-TIMEOUT: Final[int] = 43
 
 
 @dataclass
@@ -70,7 +61,7 @@ def build_recipe(file: Path, path: Path, args: list[str]) -> tuple[str, BuildRes
         )
     except subprocess.TimeoutExpired:
         return str(file.relative_to(path)), BuildResult(
-            code=TIMEOUT,
+            code=ExitCode.TIMEOUT,
             errors=["Recipe build dry-run timed out."],
         )
 
@@ -161,7 +152,7 @@ def rattler_bulk_build(
 
     if not files:
         print_err(f"No `recipe.yaml` files found in: {path}")
-        sys.exit(NO_FILES_FOUND)
+        sys.exit(ExitCode.NO_FILES_FOUND)
 
     # Process recipes in parallel
     thread_pool_size: Final[int] = mp.cpu_count()
@@ -176,7 +167,7 @@ def rattler_bulk_build(
     recipes_with_errors: list[str] = []
     error_histogram: dict[str, int] = {}
     for file, build_result in results.items():
-        if build_result.code == SUCCESS:
+        if build_result.code == ExitCode.SUCCESS:
             total_success += 1
         else:
             total_errors += 1
@@ -216,4 +207,4 @@ def rattler_bulk_build(
         create_debug_file(debug_log, results, error_histogram)
 
     print(json.dumps(final_output, indent=2))
-    sys.exit(SUCCESS if percent_success >= min_success_rate else MISSED_SUCCESS_THRESHOLD)
+    sys.exit(ExitCode.SUCCESS if percent_success >= min_success_rate else ExitCode.MISSED_SUCCESS_THRESHOLD)

--- a/conda_recipe_manager/commands/rattler_bulk_build.py
+++ b/conda_recipe_manager/commands/rattler_bulk_build.py
@@ -19,7 +19,8 @@ from typing import Final, Optional, cast
 import click
 
 from conda_recipe_manager.commands.utils.print import print_err
-from conda_recipe_manager.commands.utils.types import V1_FORMAT_RECIPE_FILE_NAME, ExitCode
+from conda_recipe_manager.commands.utils.types import ExitCode
+from conda_recipe_manager.parser.types import V1_FORMAT_RECIPE_FILE_NAME
 
 # When performing a bulk operation, overall "success" is indicated by the % of recipe files that were built
 # "successfully"

--- a/conda_recipe_manager/commands/utils/print.py
+++ b/conda_recipe_manager/commands/utils/print.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import sys
 from typing import Final
 
-from conda_recipe_manager.parser.types import MessageCategory, MessageTable
+from conda_recipe_manager.types import MessageCategory, MessageTable
 
 
 def print_out(*args, print_enabled: bool = True, **kwargs) -> None:  # type: ignore

--- a/conda_recipe_manager/commands/utils/types.py
+++ b/conda_recipe_manager/commands/utils/types.py
@@ -6,12 +6,6 @@ Description:    Contains types and constants used by CLI commands.
 from __future__ import annotations
 
 from enum import IntEnum
-from typing import Final
-
-# Pre-CEP-13 name of the recipe file
-V0_FORMAT_RECIPE_FILE_NAME: Final[str] = "meta.yaml"
-# Required file name for the recipe, specified in CEP-13
-V1_FORMAT_RECIPE_FILE_NAME: Final[str] = "recipe.yaml"
 
 
 class ExitCode(IntEnum):

--- a/conda_recipe_manager/commands/utils/types.py
+++ b/conda_recipe_manager/commands/utils/types.py
@@ -1,0 +1,46 @@
+"""
+File:           types.py
+Description:    Contains types and constants used by CLI commands.
+"""
+
+from __future__ import annotations
+
+from enum import IntEnum
+from typing import Final
+
+# Pre-CEP-13 name of the recipe file
+V0_FORMAT_RECIPE_FILE_NAME: Final[str] = "meta.yaml"
+# Required file name for the recipe, specified in CEP-13
+V1_FORMAT_RECIPE_FILE_NAME: Final[str] = "recipe.yaml"
+
+
+class ExitCode(IntEnum):
+    """
+    Error codes to return upon script completion.
+
+    All commands define their error codes here, so that they can interop with unique codes for errors without overlap.
+    """
+
+    ## All Scripts ##
+    SUCCESS = 0
+    CLICK_ERROR = 1  # Controlled by the `click` library
+    CLICK_USAGE = 2  # Controlled by the `click` library
+    NO_FILES_FOUND = 3
+    # In bulk operation mode, this indicates that the % success threshold was not met
+    MISSED_SUCCESS_THRESHOLD = 42
+    TIMEOUT = 43
+
+    ## convert  ##
+    # Errors are roughly ordered by increasing severity
+    RENDER_WARNINGS = 100
+    RENDER_ERRORS = 101
+    PARSE_EXCEPTION = 102
+    RENDER_EXCEPTION = 103
+    READ_EXCEPTION = 104
+    PRE_PROCESS_EXCEPTION = 105
+    ILLEGAL_OPERATION = 106
+
+    ## rattler-bulk-build ##
+    # NOTE: There may be overlap with rattler-build
+
+    ## update-feedstock ##

--- a/conda_recipe_manager/parser/recipe_parser.py
+++ b/conda_recipe_manager/parser/recipe_parser.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import ast
 import difflib
+import hashlib
 import json
 import re
 import sys
@@ -1585,3 +1586,13 @@ class RecipeParser(IsModifiable):
                 self._init_content.splitlines(), self.render().splitlines(), fromfile="original", tofile="current"
             )
         )
+
+    def calc_sha256(self) -> str:
+        """
+        Generates a SHA-256 hash of recipe's contents. This hash is the same as if the current recipe state was written
+        to a file. NOTE: This may not be the same as the original recipe file as the parser will auto-format text.
+        :returns: SHA-256 hash of the current recipe state.
+        """
+        # NOTE: If we need to hash larger recipes, we may want to consider a buffered
+        #       approach: https://stackoverflow.com/questions/22058048/hashing-a-file-in-python
+        return hashlib.sha256(self.render().encode()).hexdigest()

--- a/conda_recipe_manager/parser/recipe_parser_convert.py
+++ b/conda_recipe_manager/parser/recipe_parser_convert.py
@@ -28,8 +28,8 @@ from conda_recipe_manager.parser._utils import (
 )
 from conda_recipe_manager.parser.enums import SchemaVersion
 from conda_recipe_manager.parser.recipe_parser import RecipeParser
-from conda_recipe_manager.parser.types import CURRENT_RECIPE_SCHEMA_FORMAT, MessageCategory, MessageTable
-from conda_recipe_manager.types import JsonPatchType, JsonType, Primitives, SentinelType
+from conda_recipe_manager.parser.types import CURRENT_RECIPE_SCHEMA_FORMAT
+from conda_recipe_manager.types import JsonPatchType, JsonType, MessageCategory, MessageTable, Primitives, SentinelType
 
 
 class RecipeParserConvert(RecipeParser):

--- a/conda_recipe_manager/parser/types.py
+++ b/conda_recipe_manager/parser/types.py
@@ -5,7 +5,7 @@ Description:    Provides public types, type aliases, constants, and small classe
 
 from __future__ import annotations
 
-from enum import StrEnum, auto
+from enum import StrEnum
 from typing import Final
 
 from conda_recipe_manager.parser.enums import SchemaVersion
@@ -117,80 +117,3 @@ class MultilineVariant(StrEnum):
     CARROT = ">"
     CARROT_PLUS = ">+"
     CARROT_MINUS = ">-"
-
-
-class MessageCategory(StrEnum):
-    """
-    Categories to classify `RecipeParser` messages into.
-    """
-
-    EXCEPTION = auto()
-    ERROR = auto()
-    WARNING = auto()
-
-
-class MessageTable:
-    """
-    Stores and tags messages that may come up during `RecipeParser` operations. It is up to the client program to
-    handle the logging of these messages.
-    """
-
-    def __init__(self) -> None:
-        """
-        Constructs an empty message table
-        """
-        self._tbl: dict[MessageCategory, list[str]] = {}
-
-    def add_message(self, category: MessageCategory, message: str) -> None:
-        """
-        Adds a message to the table
-        :param category:
-        :param message:
-        """
-        if category not in self._tbl:
-            self._tbl[category] = []
-        self._tbl[category].append(message)
-
-    def get_messages(self, category: MessageCategory) -> list[str]:
-        """
-        Returns all the messages stored in a given category
-        :param category: Category to target
-        :returns: A list containing all the messages stored in a category.
-        """
-        if category not in self._tbl:
-            return []
-        return self._tbl[category]
-
-    def get_message_count(self, category: MessageCategory) -> int:
-        """
-        Returns how many messages are stored in a given category
-        :param category: Category to target
-        :returns: A list containing all the messages stored in a category.
-        """
-        if category not in self._tbl:
-            return 0
-        return len(self._tbl[category])
-
-    def get_totals_message(self) -> str:
-        """
-        Convenience function that returns a displayable count of the number of warnings and errors contained in the
-        messaging object.
-        :returns: A message indicating the number of errors and warnings that have been accumulated. If there are none,
-                  an empty string is returned.
-        """
-        if not self._tbl:
-            return ""
-
-        def _pluralize(n: int, s: str) -> str:
-            if n == 1:
-                return s
-            return f"{s}s"
-
-        num_errors: Final[int] = 0 if MessageCategory.ERROR not in self._tbl else len(self._tbl[MessageCategory.ERROR])
-        errors: Final[str] = f"{num_errors} " + _pluralize(num_errors, "error")
-        num_warnings: Final[int] = (
-            0 if MessageCategory.WARNING not in self._tbl else len(self._tbl[MessageCategory.WARNING])
-        )
-        warnings: Final[str] = f"{num_warnings} " + _pluralize(num_warnings, "warning")
-
-        return f"{errors} and {warnings} were found."

--- a/conda_recipe_manager/parser/types.py
+++ b/conda_recipe_manager/parser/types.py
@@ -23,6 +23,11 @@ NodeValue = Primitives | list[str]
 # considered "0". When converting to the V1 format, we'll use this constant value.
 CURRENT_RECIPE_SCHEMA_FORMAT: Final[int] = SchemaVersion.V1.value
 
+# Pre-CEP-13 name of the recipe file
+V0_FORMAT_RECIPE_FILE_NAME: Final[str] = "meta.yaml"
+# Required file name for the recipe, specified in CEP-13
+V1_FORMAT_RECIPE_FILE_NAME: Final[str] = "recipe.yaml"
+
 # Indicates how many spaces are in a level of indentation
 TAB_SPACE_COUNT: Final[int] = 2
 TAB_AS_SPACES: Final[str] = " " * TAB_SPACE_COUNT

--- a/conda_recipe_manager/types.py
+++ b/conda_recipe_manager/types.py
@@ -6,6 +6,7 @@ Description:    Provides public types, type aliases, constants, and small classe
 from __future__ import annotations
 
 from collections.abc import Hashable
+from enum import StrEnum, auto
 from typing import Final, TypeVar, Union
 
 # Base types that can store value
@@ -38,3 +39,81 @@ H = TypeVar("H", bound=Hashable)
 # All sentinel values used in this module should be constructed with this class, for typing purposes.
 class SentinelType:
     pass
+
+
+class MessageCategory(StrEnum):
+    """
+    Categories to classify messages into.
+    """
+
+    EXCEPTION = auto()
+    ERROR = auto()
+    WARNING = auto()
+
+
+class MessageTable:
+    """
+    Stores and tags messages that may come up during library operations. It is up to the client program to handle the
+    logging of these messages. In other words, this class aims to keep logging out of the library code by providing
+    an object that can track debugging information.
+    """
+
+    def __init__(self) -> None:
+        """
+        Constructs an empty message table
+        """
+        self._tbl: dict[MessageCategory, list[str]] = {}
+
+    def add_message(self, category: MessageCategory, message: str) -> None:
+        """
+        Adds a message to the table
+        :param category:
+        :param message:
+        """
+        if category not in self._tbl:
+            self._tbl[category] = []
+        self._tbl[category].append(message)
+
+    def get_messages(self, category: MessageCategory) -> list[str]:
+        """
+        Returns all the messages stored in a given category
+        :param category: Category to target
+        :returns: A list containing all the messages stored in a category.
+        """
+        if category not in self._tbl:
+            return []
+        return self._tbl[category]
+
+    def get_message_count(self, category: MessageCategory) -> int:
+        """
+        Returns how many messages are stored in a given category
+        :param category: Category to target
+        :returns: A list containing all the messages stored in a category.
+        """
+        if category not in self._tbl:
+            return 0
+        return len(self._tbl[category])
+
+    def get_totals_message(self) -> str:
+        """
+        Convenience function that returns a displayable count of the number of warnings and errors contained in the
+        messaging object.
+        :returns: A message indicating the number of errors and warnings that have been accumulated. If there are none,
+                  an empty string is returned.
+        """
+        if not self._tbl:
+            return ""
+
+        def _pluralize(n: int, s: str) -> str:
+            if n == 1:
+                return s
+            return f"{s}s"
+
+        num_errors: Final[int] = 0 if MessageCategory.ERROR not in self._tbl else len(self._tbl[MessageCategory.ERROR])
+        errors: Final[str] = f"{num_errors} " + _pluralize(num_errors, "error")
+        num_warnings: Final[int] = (
+            0 if MessageCategory.WARNING not in self._tbl else len(self._tbl[MessageCategory.WARNING])
+        )
+        warnings: Final[str] = f"{num_warnings} " + _pluralize(num_warnings, "warning")
+
+        return f"{errors} and {warnings} were found."

--- a/tests/parser/test_recipe_parser.py
+++ b/tests/parser/test_recipe_parser.py
@@ -2368,3 +2368,21 @@ def test_diff() -> None:
         " multi_level:\n"
         "   list_1:"
     )
+
+
+@pytest.mark.parametrize(
+    "file,expected",
+    [
+        ("simple-recipe.yaml", "359215c5ac3460d07470f2e3f524ed24154ff2eb7d274feb98149e6949c2ddbe"),
+        ("v1_format/v1_simple-recipe.yaml", "68c0b7fd829c17715b5b9941c882eda3bb70cb1dcef8cc08a55a9ee2b959fb7f"),
+        ("types-toml.yaml", "e117d210da9ea6507fdea856ee96407265aec40cbc58432aa6e1c7e31998a686"),
+        ("v1_format/v1_types-toml.yaml", "3474ed870eea9c8efbd248d24de8bdf54ad8651a7aed06d240f118272d8a3fd1"),
+        ("v1_format/v1_boto.yaml", "b42349254d020ffeda77f3068e8ad8804a92d1c7b89eb0f3d45632b38fc0a3bc"),
+    ],
+)
+def test_calc_sha256(file: str, expected: str) -> None:
+    """
+    Tests hashing a recipe parser's state with SHA-256
+    """
+    parser = load_recipe(file)
+    assert parser.calc_sha256() == expected

--- a/tests/parser/test_recipe_parser_convert.py
+++ b/tests/parser/test_recipe_parser_convert.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import pytest
 
 from conda_recipe_manager.parser.recipe_parser_convert import RecipeParserConvert
-from conda_recipe_manager.parser.types import MessageCategory
+from conda_recipe_manager.types import MessageCategory
 from tests.file_loading import TEST_FILES_PATH, load_file, load_recipe_convert
 
 


### PR DESCRIPTION
These are good ideas that have been cherry-picked from more experimental branches.

- V* recipe file name constants are now centralized
- Messaging classes are now available in a more generic module. They are no longer in the `parser` module
- Error code management for CLI commands are now centralized
- `rattler-bulk-build` now requires a directory to be passed-in
- The `RecipeParser` class now provides the ability to generate a SHA-256 hash of the recipe's contents