### PR TITLE
Improves test performance

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,12 +57,6 @@ repos:
     name: mypy
     pass_filenames: false
     entry: make analyze
-  - id: pytest
-    language: system
-    name: pytest
-    always_run: true
-    pass_filenames: false
-    entry: make test
   - id: pytest-cov
     language: system
     name: pytest-cov


### PR DESCRIPTION
Having pre-commit run make test and make test-cov is redundant. Running test coverage inherently runs all the tests.