### PR TITLE
The load_file() test utility now forces a relative path to the test directory

### DIFF
--- a/tests/commands/test_convert.py
+++ b/tests/commands/test_convert.py
@@ -42,4 +42,4 @@ def test_convert_single_file() -> None:
     # This recipe has warnings
     assert result.exit_code == 100
     # `crm convert` prints an additional newline
-    assert result.stdout == load_file(f"{TEST_FILES_PATH}/v1_format/v1_simple-recipe.yaml") + "\n"
+    assert result.stdout == load_file("v1_format/v1_simple-recipe.yaml") + "\n"

--- a/tests/file_loading.py
+++ b/tests/file_loading.py
@@ -20,12 +20,13 @@ R = TypeVar("R", bound=RecipeReader)
 
 def load_file(file: Path | str) -> str:
     """
-    Loads a file into a single string
+    Loads a file into a single string. Assumes the file is under the `TEST_FILES_PATH` directory, which is the standard
+    location for all testing files.
 
-    :param file: Filename of the file to read
+    :param file: Filename/relative path of the file to read
     :returns: Text from the file
     """
-    return Path(file).read_text(encoding="utf-8")
+    return Path(TEST_FILES_PATH / file).read_text(encoding="utf-8")
 
 
 def load_recipe(file_name: str, recipe_parser: Type[R]) -> R:
@@ -35,7 +36,7 @@ def load_recipe(file_name: str, recipe_parser: Type[R]) -> R:
     :param file_name: File name of the test recipe to load
     :returns: RecipeParser instance, based on the file
     """
-    recipe = load_file(TEST_FILES_PATH / file_name)
+    recipe = load_file(file_name)
     return recipe_parser(recipe)
 
 
@@ -50,10 +51,9 @@ def load_recipe_graph(recipes: list[str]) -> RecipeGraph:
     failed: set[str] = set()
     for recipe in recipes:
         try:
-            path = f"{TEST_FILES_PATH}/{recipe}"
-            parser = RecipeParserDeps(load_file(path))
+            parser = RecipeParserDeps(load_file(recipe))
             tbl[parser.calc_sha256()] = parser
         except Exception:  # pylint: disable=broad-exception-caught
-            failed.add(path)
+            failed.add(recipe)
 
     return RecipeGraph(tbl, failed)

--- a/tests/parser/test_pickle_integration.py
+++ b/tests/parser/test_pickle_integration.py
@@ -15,7 +15,7 @@ from conda_recipe_manager.parser.recipe_parser_deps import RecipeParserDeps
 from conda_recipe_manager.parser.selector_parser import SelectorParser
 from conda_recipe_manager.parser.types import SchemaVersion
 from conda_recipe_manager.types import SentinelType
-from tests.file_loading import TEST_FILES_PATH, load_file
+from tests.file_loading import load_file
 
 
 def test_pickle_integration_sentinel_type() -> None:
@@ -54,7 +54,7 @@ def test_pickle_integration_recipe_parsers(file: str, constructor: Callable[[str
     More details about this problem can be found in this PR:
       https://github.com/conda-incubator/conda-recipe-manager/pull/105
     """
-    file_text = load_file(TEST_FILES_PATH / file)
+    file_text = load_file(file)
     parser = constructor(file_text)
     assert pickle.loads(pickle.dumps(parser)).render() == parser.render()  # type: ignore[misc]
 

--- a/tests/parser/test_recipe_parser.py
+++ b/tests/parser/test_recipe_parser.py
@@ -10,7 +10,7 @@ from conda_recipe_manager.parser.enums import SelectorConflictMode
 from conda_recipe_manager.parser.exceptions import JsonPatchValidationException
 from conda_recipe_manager.parser.recipe_parser import RecipeParser
 from tests.constants import SIMPLE_DESCRIPTION
-from tests.file_loading import TEST_FILES_PATH, load_file, load_recipe
+from tests.file_loading import load_file, load_recipe
 
 ## JINJA Variables ##
 
@@ -119,7 +119,7 @@ def test_add_selector() -> None:
         "/multi_level/list_2/1",
     ]
 
-    assert parser.render() == load_file(f"{TEST_FILES_PATH}/simple-recipe_test_add_selector.yaml")
+    assert parser.render() == load_file("simple-recipe_test_add_selector.yaml")
     assert parser.is_modified()
 
 
@@ -153,7 +153,7 @@ def test_remove_selector() -> None:
     assert parser.remove_selector("/requirements/empty_field2") == "[unix and win]"
     assert not parser.get_selector_paths("[unix and win]")
 
-    assert parser.render() == load_file(f"{TEST_FILES_PATH}/simple-recipe_test_remove_selector.yaml")
+    assert parser.render() == load_file("simple-recipe_test_remove_selector.yaml")
     assert parser.is_modified()
 
 
@@ -181,7 +181,7 @@ def test_add_comment(file: str, ops: list[tuple[str, str]], expected: str) -> No
     for path, comment in ops:
         parser.add_comment(path, comment)
     assert parser.is_modified()
-    assert parser.render() == load_file(f"{TEST_FILES_PATH}/{expected}")
+    assert parser.render() == load_file(expected)
 
 
 @pytest.mark.parametrize(
@@ -767,7 +767,7 @@ def test_patch_add() -> None:
 
     # Sanity check: validate all modifications
     assert parser.is_modified()
-    assert parser.render() == load_file(f"{TEST_FILES_PATH}/simple-recipe_test_patch_add.yaml")
+    assert parser.render() == load_file("simple-recipe_test_patch_add.yaml")
 
 
 def test_patch_remove() -> None:
@@ -831,7 +831,7 @@ def test_patch_remove() -> None:
 
     # Sanity check: validate all modifications
     assert parser.is_modified()
-    assert parser.render() == load_file(f"{TEST_FILES_PATH}/simple-recipe_test_patch_remove.yaml")
+    assert parser.render() == load_file("simple-recipe_test_patch_remove.yaml")
 
 
 def test_patch_replace() -> None:
@@ -929,7 +929,7 @@ def test_patch_replace() -> None:
     # Sanity check: validate all modifications
     assert parser.is_modified()
     # NOTE: That patches, as of writing, cannot preserve selectors
-    assert parser.render() == load_file(f"{TEST_FILES_PATH}/simple-recipe_test_patch_replace.yaml")
+    assert parser.render() == load_file("simple-recipe_test_patch_replace.yaml")
 
 
 def test_patch_move() -> None:
@@ -954,7 +954,7 @@ def test_patch_move() -> None:
         }
     )
     assert not parser.is_modified()
-    assert parser.render() == load_file(f"{TEST_FILES_PATH}/simple-recipe.yaml")
+    assert parser.render() == load_file("simple-recipe.yaml")
 
     # Simple move
     assert parser.patch(
@@ -1004,7 +1004,7 @@ def test_patch_move() -> None:
     # Sanity check: validate all modifications
     assert parser.is_modified()
     # NOTE: That patches, as of writing, cannot preserve selectors
-    assert parser.render() == load_file(f"{TEST_FILES_PATH}/simple-recipe_test_patch_move.yaml")
+    assert parser.render() == load_file("simple-recipe_test_patch_move.yaml")
 
 
 def test_patch_copy() -> None:
@@ -1061,7 +1061,7 @@ def test_patch_copy() -> None:
     # Sanity check: validate all modifications
     assert parser.is_modified()
     # NOTE: That patches, as of writing, cannot preserve selectors
-    assert parser.render() == load_file(f"{TEST_FILES_PATH}/simple-recipe_test_patch_copy.yaml")
+    assert parser.render() == load_file("simple-recipe_test_patch_copy.yaml")
 
 
 def test_search_and_patch() -> None:
@@ -1070,7 +1070,7 @@ def test_search_and_patch() -> None:
     """
     parser = load_recipe("simple-recipe.yaml", RecipeParser)
     assert parser.search_and_patch(r"py.*", {"op": "replace", "value": "conda"}, True)
-    assert parser.render() == load_file(f"{TEST_FILES_PATH}/simple-recipe_test_search_and_patch.yaml")
+    assert parser.render() == load_file("simple-recipe_test_search_and_patch.yaml")
     assert parser.is_modified()
 
 

--- a/tests/parser/test_recipe_parser_convert.py
+++ b/tests/parser/test_recipe_parser_convert.py
@@ -8,7 +8,7 @@ import pytest
 
 from conda_recipe_manager.parser.recipe_parser_convert import RecipeParserConvert
 from conda_recipe_manager.types import MessageCategory
-from tests.file_loading import TEST_FILES_PATH, load_file, load_recipe
+from tests.file_loading import load_file, load_recipe
 
 
 @pytest.mark.parametrize(
@@ -34,9 +34,7 @@ def test_pre_process_recipe_text(input_file: str, expected_file: str) -> None:
     :param input_file: Test input recipe file name
     :param expected_file: Name of the file containing the expected output of a test instance
     """
-    assert RecipeParserConvert.pre_process_recipe_text(load_file(f"{TEST_FILES_PATH}/{input_file}")) == load_file(
-        f"{TEST_FILES_PATH}/{expected_file}"
-    )
+    assert RecipeParserConvert.pre_process_recipe_text(load_file(input_file)) == load_file(expected_file)
 
 
 @pytest.mark.parametrize(
@@ -181,7 +179,7 @@ def test_render_to_v1_recipe_format(file_base: str, errors: list[str], warnings:
     """
     parser = load_recipe(file_base, RecipeParserConvert)
     result, tbl, _ = parser.render_to_v1_recipe_format()
-    assert result == load_file(f"{TEST_FILES_PATH}/v1_format/v1_{file_base}")
+    assert result == load_file(f"v1_format/v1_{file_base}")
     assert tbl.get_messages(MessageCategory.ERROR) == errors
     assert tbl.get_messages(MessageCategory.WARNING) == warnings
     # Ensure that the original file was untouched

--- a/tests/parser/test_recipe_reader.py
+++ b/tests/parser/test_recipe_reader.py
@@ -12,7 +12,7 @@ from conda_recipe_manager.parser.enums import SchemaVersion
 from conda_recipe_manager.parser.recipe_parser import RecipeReader
 from conda_recipe_manager.types import JsonType, Primitives
 from tests.constants import SIMPLE_DESCRIPTION
-from tests.file_loading import TEST_FILES_PATH, load_file, load_recipe
+from tests.file_loading import load_file, load_recipe
 
 # Multiline string used to validate interpretation of the various multiline variations YAML allows
 QUICK_FOX_PIPE: Final[str] = "The quick brown\n{{fox}}\n\njumped over the lazy dog\n"
@@ -47,7 +47,7 @@ def test_construction(file: str, schema_version: SchemaVersion) -> None:
     :param file: Recipe file to test with
     :param schema_version: Schema version to match
     """
-    types_toml = load_file(f"{TEST_FILES_PATH}/{file}")
+    types_toml = load_file(file)
     parser = RecipeReader(types_toml)
     assert parser._init_content == types_toml  # pylint: disable=protected-access
     assert parser._vars_tbl == {  # pylint: disable=protected-access
@@ -77,10 +77,10 @@ def test_str(file: str, out_file: str) -> None:
     :param out_file: Output string to match
     """
     parser = load_recipe(file, RecipeReader)
-    assert str(parser) == load_file(f"{TEST_FILES_PATH}/{out_file}")
+    assert str(parser) == load_file(out_file)
     # Regression test: Run a function a second time to ensure that `SelectorInfo::__str__()` doesn't accidentally purge
     # the underlying stack when the string is being rendered.
-    assert str(parser) == load_file(f"{TEST_FILES_PATH}/{out_file}")
+    assert str(parser) == load_file(out_file)
     assert not parser.is_modified()
 
 
@@ -113,7 +113,7 @@ def test_loading_obj_in_list() -> None:
     """
     Regression test: at one point, the parser would crash loading this file, containing an object in a list.
     """
-    replace = load_file(f"{TEST_FILES_PATH}/simple-recipe_test_patch_replace.yaml")
+    replace = load_file("simple-recipe_test_patch_replace.yaml")
     parser = RecipeReader(replace)
     assert parser.render() == replace
 
@@ -148,7 +148,7 @@ def test_round_trip(file: str) -> None:
     Test "eating our own dog food"/round-tripping the parser: Take a recipe, construct a parser, re-render and
     ensure the output matches the input.
     """
-    expected: Final[str] = load_file(f"{TEST_FILES_PATH}/{file}")
+    expected: Final[str] = load_file(file)
     parser = RecipeReader(expected)
     assert parser.render() == expected
 


### PR DESCRIPTION
This has been done to _encourage_ tests to use the standard testing directory. This also reduces the number of f-strings we have to do something that is repeated all over the code.