### PR TITLE
Completes the first iteration of `from_recipe()`

### DIFF
--- a/conda_recipe_manager/fetcher/artifact_fetcher.py
+++ b/conda_recipe_manager/fetcher/artifact_fetcher.py
@@ -1,33 +1,100 @@
 """
-:Description: TODO
+:Description: Module that provides general Artifact Fetching utilities and factory methods.
 """
 
 from __future__ import annotations
 
-from typing import Final, cast
+from typing import cast
 
 from conda_recipe_manager.fetcher.base_artifact_fetcher import BaseArtifactFetcher
+from conda_recipe_manager.fetcher.exceptions import FetchUnsupportedError
+from conda_recipe_manager.fetcher.git_artifact_fetcher import GitArtifactFetcher
+from conda_recipe_manager.fetcher.http_artifact_fetcher import HttpArtifactFetcher
 from conda_recipe_manager.parser.recipe_reader import RecipeReader
+from conda_recipe_manager.parser.types import SchemaVersion
 from conda_recipe_manager.types import Primitives
-
-# Identifying string used to flag temp files and directories created by this module.
-_ARTIFACT_FETCHER_FILE_ID: Final[str] = "crm_artifact_fetcher"
+from conda_recipe_manager.utils.typing import optional_str
 
 
-def from_recipe(recipe: RecipeReader) -> list[BaseArtifactFetcher]:
+def _render_git_key(recipe: RecipeReader, key: str) -> str:
     """
-    TODO Complete: construct from a recipe file directly
+    Given the V0 name for a target key used in git-backed recipe sources, return the equivalent key for the recipe
+    format.
+
+    :param recipe: Parser instance for the target recipe
+    :param key: V0 Name for the target git source key
+    :returns: The equivalent key for the recipe's schema.
+    """
+    match recipe.get_schema_version():
+        case SchemaVersion.V0:
+            return key
+        case SchemaVersion.V1:
+            match key:
+                case "git_url":
+                    return "git"
+                case "git_branch":
+                    return "branch"
+                case "git_tag":
+                    return "tag"
+                case "git_rev":
+                    return "rev"
+                case _:  # If this case happens, a developer made a typo.
+                    return ""
+
+
+def from_recipe(recipe: RecipeReader, ignore_unsupported: bool = False) -> list[BaseArtifactFetcher]:
+    """
+    Parses and constructs a list of artifact-fetching objects based on the contents of a recipe.
+
+    NOTE: To keep this function fast, this function does not invoke `fetch()` on any artifacts found. It is up to the
+    caller to manage artifact retrieval.
+
+    Currently supported sources (per recipe schema):
+      - HTTP/HTTPS with tar or zip artifacts (V0 and V1)
+      - git (unauthenticated) (V0 and V1)
+
+    :param recipe: Parser instance for the target recipe
+    :param ignore_unsupported: (Optional) If set to `True`, ignore currently unsupported artifacts found in the source
+        section and return the list of supported sources. Otherwise, throw an exception.
+    :raises FetchUnsupportedError: If an unsupported source format is found.
+    :returns: A list containing one Artifact Fetcher instance per source found in the recipe file.
     """
     sources: list[BaseArtifactFetcher] = []
-    # TODO add source-specific parser?
     parsed_sources = cast(
-        dict[str, Primitives] | list[dict[str, Primitives]], recipe.get_value("/source", sub_vars=True)
+        dict[str, Primitives] | list[dict[str, Primitives]], recipe.get_value("/source", sub_vars=True, default=[])
     )
+    # TODO Handle selector evaluation/determine how common it is to have a selector in `/source`
+
+    # Normalize to a list to handle both single and multi-source cases.
     if not isinstance(parsed_sources, list):
         parsed_sources = [parsed_sources]
 
-    # TODO Use `sub_vars` on `get_value()`
-    # TODO Handle selector evaluation
-    for _ in parsed_sources:
-        pass
+    recipe_name = recipe.get_recipe_name()
+    if recipe_name is None:
+        recipe_name = "Unknown Recipe"
+
+    for i, parsed_source in enumerate(parsed_sources):
+        # NOTE: `optional_str()` is used to force evaluation of potentially unknown types to strings for input
+        #       sanitation purposes.
+        # NOTE: `url` is the same for both V0 and V1 formats.
+        url = optional_str(parsed_source.get("url"))
+        git_url = optional_str(parsed_source.get(_render_git_key(recipe, "git_url")))
+
+        src_name = recipe_name if len(parsed_sources) == 1 else f"{recipe_name}_{i}"
+
+        if url is not None:
+            sources.append(HttpArtifactFetcher(src_name, url))
+        elif git_url is not None:
+            sources.append(
+                GitArtifactFetcher(
+                    src_name,
+                    git_url,
+                    branch=optional_str(parsed_source.get(_render_git_key(recipe, "git_branch"))),
+                    tag=optional_str(parsed_source.get(_render_git_key(recipe, "git_tag"))),
+                    rev=optional_str(parsed_source.get(_render_git_key(recipe, "git_rev"))),
+                )
+            )
+        elif not ignore_unsupported:
+            raise FetchUnsupportedError(f"{recipe_name} contains an unsupported source object at `/source/{i}`.")
+
     return sources

--- a/conda_recipe_manager/fetcher/artifact_fetcher.py
+++ b/conda_recipe_manager/fetcher/artifact_fetcher.py
@@ -23,6 +23,7 @@ def _render_git_key(recipe: RecipeReader, key: str) -> str:
 
     :param recipe: Parser instance for the target recipe
     :param key: V0 Name for the target git source key
+    :raises FetchUnsupportedError: If an unrecognized key has been provided.
     :returns: The equivalent key for the recipe's schema.
     """
     match recipe.get_schema_version():
@@ -38,8 +39,10 @@ def _render_git_key(recipe: RecipeReader, key: str) -> str:
                     return "tag"
                 case "git_rev":
                     return "rev"
-                case _:  # If this case happens, a developer made a typo.
-                    return ""
+                # If this case happens, a developer made a typo. Therefore it should ignore the `ignore_unsupported`
+                # flag in the hopes of being caught early by a unit test.
+                case _:
+                    raise FetchUnsupportedError(f"The following key is not supported for git sources: {key}")
 
 
 def from_recipe(recipe: RecipeReader, ignore_unsupported: bool = False) -> list[BaseArtifactFetcher]:

--- a/conda_recipe_manager/fetcher/exceptions.py
+++ b/conda_recipe_manager/fetcher/exceptions.py
@@ -11,6 +11,21 @@ class FetcherException(Exception):
     """
 
 
+class FetchUnsupportedError(FetcherException):
+    """
+    An issue occurred because the target artifact/source format is unsupported.
+    """
+
+    def __init__(self, message: str):
+        """
+        Constructs a FetchUnsupportedError Exception.
+
+        :param message: String description of the issue encountered.
+        """
+        self.message = message if len(message) else "The target artifact format is unsupported."
+        super().__init__(self.message)
+
+
 class FetchError(FetcherException):
     """
     General exception to be thrown when there is a failure to fetch an artifact.

--- a/conda_recipe_manager/parser/recipe_reader.py
+++ b/conda_recipe_manager/parser/recipe_reader.py
@@ -40,6 +40,7 @@ from conda_recipe_manager.parser.enums import SchemaVersion
 from conda_recipe_manager.parser.types import TAB_AS_SPACES, TAB_SPACE_COUNT, MultilineVariant
 from conda_recipe_manager.types import PRIMITIVES_TUPLE, JsonType, Primitives, SentinelType
 from conda_recipe_manager.utils.cryptography.hashing import hash_str
+from conda_recipe_manager.utils.typing import optional_str
 
 # Import guard: Fallback to `SafeLoader` if `CSafeLoader` isn't available
 try:
@@ -842,14 +843,9 @@ class RecipeReader(IsModifiable):
             returned instead.
         """
 
-        def _optional_str(val: JsonType) -> Optional[str]:
-            if val is None:
-                return None
-            return str(val)
-
         if self._schema_version == SchemaVersion.V1 and self.is_multi_output():
-            return _optional_str(self.get_value("/recipe/name", sub_vars=True, default=None))
-        return _optional_str(self.get_value("/package/name", sub_vars=True, default=None))
+            return optional_str(self.get_value("/recipe/name", sub_vars=True, default=None))
+        return optional_str(self.get_value("/package/name", sub_vars=True, default=None))
 
     ## General Convenience Functions ##
 

--- a/conda_recipe_manager/parser/recipe_reader.py
+++ b/conda_recipe_manager/parser/recipe_reader.py
@@ -841,6 +841,7 @@ class RecipeReader(IsModifiable):
         :returns: The name associated with the recipe file. In the unlikely event that no name is found, `None` is
             returned instead.
         """
+
         def _optional_str(val: JsonType) -> Optional[str]:
             if val is None:
                 return None

--- a/conda_recipe_manager/parser/recipe_reader.py
+++ b/conda_recipe_manager/parser/recipe_reader.py
@@ -830,6 +830,26 @@ class RecipeReader(IsModifiable):
 
         return paths
 
+    def get_recipe_name(self) -> Optional[str]:
+        """
+        Convenience function that retrieves the "name" of a recipe file. This can be used as an identifier, but it
+        is not guaranteed to be unique. In V0 recipes and single-output V1 recipes, this is known as the "package name".
+
+        In V1 recipe files, the name must be included to pass the schema check that should be enforced by any build
+        system.
+
+        :returns: The name associated with the recipe file. In the unlikely event that no name is found, `None` is
+            returned instead.
+        """
+        def _optional_str(val: JsonType) -> Optional[str]:
+            if val is None:
+                return None
+            return str(val)
+
+        if self._schema_version == SchemaVersion.V1 and self.is_multi_output():
+            return _optional_str(self.get_value("/recipe/name", sub_vars=True, default=None))
+        return _optional_str(self.get_value("/package/name", sub_vars=True, default=None))
+
     ## General Convenience Functions ##
 
     def is_multi_output(self) -> bool:

--- a/conda_recipe_manager/utils/typing.py
+++ b/conda_recipe_manager/utils/typing.py
@@ -1,0 +1,21 @@
+"""
+:Description: Provides typing utility functions.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from conda_recipe_manager.types import JsonType
+
+
+def optional_str(val: JsonType) -> Optional[str]:
+    """
+    Forces evaluation of a variable to a string or to `None`. In other words, like `str()`, but preserves `None`.
+
+    :param val: Value to convert to a string.
+    :returns: String equivalent of a value or None.
+    """
+    if val is None:
+        return None
+    return str(val)

--- a/tests/fetcher/test_artifact_fetcher.py
+++ b/tests/fetcher/test_artifact_fetcher.py
@@ -1,0 +1,97 @@
+"""
+:Description: TODO
+"""
+
+from __future__ import annotations
+
+from typing import Final, Type
+
+import pytest
+
+from conda_recipe_manager.fetcher.artifact_fetcher import from_recipe
+from conda_recipe_manager.fetcher.base_artifact_fetcher import BaseArtifactFetcher
+from conda_recipe_manager.fetcher.exceptions import FetchUnsupportedError
+from conda_recipe_manager.fetcher.git_artifact_fetcher import GitArtifactFetcher
+from conda_recipe_manager.fetcher.http_artifact_fetcher import HttpArtifactFetcher
+from conda_recipe_manager.parser.recipe_reader import RecipeReader
+from tests.file_loading import TEST_FILES_PATH, load_recipe
+
+
+@pytest.mark.parametrize(
+    "file,expected",
+    [
+        ## V0 Format ##
+        ("types-toml.yaml", [HttpArtifactFetcher]),
+        ("multi-output.yaml", []),
+        ("git-src.yaml", [GitArtifactFetcher]),
+        ## V1 Format ##
+        ("v1_format/v1_types-toml.yaml", [HttpArtifactFetcher]),
+        ("v1_format/v1_multi-output.yaml", []),
+        ("v1_format/v1_git-src.yaml", [GitArtifactFetcher]),
+    ],
+)
+def test_from_recipe_ignore_unsupported(
+    file: str, expected: list[Type[BaseArtifactFetcher]], request: pytest.FixtureRequest
+) -> None:
+    """
+    Tests that a list of Artifact Fetchers can be derived from a parsed recipe.
+
+    NOTE: This test ensures that the correct number and type of the derived classes is constructed. It is not up to
+          this test to validate that the recipe was parsed correctly and returning the expected values from the
+          `/source` path. That should be covered by recipe parsing unit tests.
+
+    :param file: File to work against
+    :param expected: Expected list of classes to match the returned list.
+    """
+    request.getfixturevalue("fs").add_real_file(TEST_FILES_PATH / file)  # type: ignore[misc]
+    recipe = load_recipe(file, RecipeReader)
+
+    fetcher_list: Final[list[BaseArtifactFetcher]] = from_recipe(recipe, True)
+
+    assert len(fetcher_list) == len(expected)
+    for i, fetcher in enumerate(fetcher_list):
+        assert isinstance(fetcher, expected[i])
+
+
+@pytest.mark.parametrize(
+    "file",
+    [
+        ## V0 Format ##
+        "fake_source.yaml",
+        ## V1 Format ##
+        "v1_format/v1_fake_source.yaml",
+    ],
+)
+def test_from_recipe_throws_on_unsupported(file: str, request: pytest.FixtureRequest) -> None:
+    """
+    Ensures that `from_recipe()` emits the expected exception in the event that a source section cannot be parsed.
+
+    :param file: File to work against
+    """
+    request.getfixturevalue("fs").add_real_file(TEST_FILES_PATH / file)  # type: ignore[misc]
+    recipe = load_recipe(file, RecipeReader)
+
+    with pytest.raises(FetchUnsupportedError):
+        from_recipe(recipe)
+
+
+@pytest.mark.parametrize(
+    "file",
+    [
+        ## V0 Format ##
+        "fake_source.yaml",
+        ## V1 Format ##
+        "v1_format/v1_fake_source.yaml",
+    ],
+)
+def test_from_recipe_does_not_throw_on_ignore_unsupported(file: str, request: pytest.FixtureRequest) -> None:
+    """
+    Ensures that `from_recipe()` DOES NOT emit an exception in the event that a source section cannot be parsed AND the
+    `ignore_unsupported` flag is set.
+
+    :param file: File to work against
+    """
+    request.getfixturevalue("fs").add_real_file(TEST_FILES_PATH / file)  # type: ignore[misc]
+    recipe = load_recipe(file, RecipeReader)
+
+    assert not from_recipe(recipe, True)

--- a/tests/parser/test_recipe_reader.py
+++ b/tests/parser/test_recipe_reader.py
@@ -785,6 +785,33 @@ def test_find_value(file: str, value: Primitives, expected: list[str]) -> None:
 
 
 @pytest.mark.parametrize(
+    "file,expected",
+    [
+        ## V0 Format ##
+        ("types-toml.yaml", "types-toml"),
+        ("boto.yaml", "boto"),
+        ("cctools-ld64.yaml", "cctools-and-ld64"),
+        ("multi-output.yaml", None),
+        ## V1 Format ##
+        ("v1_format/v1_types-toml.yaml", "types-toml"),
+        ("v1_format/v1_boto.yaml", "boto"),
+        ("v1_format/v1_cctools-ld64.yaml", "cctools-and-ld64"),
+        ("v1_format/v1_multi-output.yaml", None),
+    ],
+)
+def test_get_recipe_name(file: str, expected: str) -> None:
+    """
+    Tests finding a value from a parsed YAML example.
+
+    :param file: File to work against
+    :param expected: Expected result of the test
+    """
+    parser = load_recipe(file, RecipeReader)
+    assert parser.get_recipe_name() == expected
+    assert not parser.is_modified()
+
+
+@pytest.mark.parametrize(
     "file,value",
     [
         ("simple-recipe.yaml", ["foo", "bar"]),

--- a/tests/test_aux_files/fake_source.yaml
+++ b/tests/test_aux_files/fake_source.yaml
@@ -1,0 +1,49 @@
+{% set name = "types-toml" %}
+{% set version = "0.10.8.6" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  dne_url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/types-toml-{{ version }}.tar.gz
+  dne_tag: foo_bar
+  sha386: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
+
+build:
+  number: 0
+  skip: true  # [py<37]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - setuptools
+    - wheel
+    - pip
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - types
+  requires:
+    - pip
+  commands:
+    - pip check
+    - test -f $SP_DIR/toml-stubs/__init__.pyi  # [unix]
+
+about:
+  home: https://github.com/python/typeshed
+  summary: Contains a fake source section that is not supported
+  description: Contains a fake source section that is not supported
+  license: Apache-2.0 AND MIT
+  license_file: LICENSE
+  license_family: OTHER
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://pypi.org/project/types-toml/
+
+extra:
+  recipe-maintainers:
+    - fhoehle
+    - conda-forge/mypy

--- a/tests/test_aux_files/v1_format/v1_fake_source.yaml
+++ b/tests/test_aux_files/v1_format/v1_fake_source.yaml
@@ -1,0 +1,54 @@
+schema_version: 1
+
+context:
+  name: types-toml
+  version: 0.10.8.6
+
+package:
+  name: ${{ name|lower }}
+  version: ${{ version }}
+
+source:
+  dne_url: https://pypi.io/packages/source/${{ name[0] }}/${{ name }}/types-toml-${{ version }}.tar.gz
+  dne_tag: foo_bar
+  sha386: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
+
+build:
+  number: 0
+  skip: match(python, "<3.7")
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - setuptools
+    - wheel
+    - pip
+    - python
+  run:
+    - python
+
+tests:
+  - python:
+      imports:
+        - types
+      pip_check: true
+  - requirements:
+      run:
+        - pip
+    script:
+      - if: unix
+        then: test -f $SP_DIR/toml-stubs/__init__.pyi
+
+about:
+  summary: Contains a fake source section that is not supported
+  description: Contains a fake source section that is not supported
+  license: Apache-2.0 AND MIT
+  license_file: LICENSE
+  homepage: https://github.com/python/typeshed
+  repository: https://github.com/python/typeshed
+  documentation: https://pypi.org/project/types-toml/
+
+extra:
+  recipe-maintainers:
+    - fhoehle
+    - conda-forge/mypy

--- a/tests/utils/test_typing.py
+++ b/tests/utils/test_typing.py
@@ -1,0 +1,35 @@
+"""
+:Description: Tests the typing utility module.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import pytest
+
+from conda_recipe_manager.types import JsonType
+from conda_recipe_manager.utils.typing import optional_str
+
+
+@pytest.mark.parametrize(
+    "val,expected",
+    [
+        (42, "42"),
+        (4.2, "4.2"),
+        (False, "False"),
+        (None, None),
+        ("null", "null"),
+        ("foobar", "foobar"),
+        ({"foo": "bar"}, "{'foo': 'bar'}"),
+        ([1, 2, 3, 4, 5], "[1, 2, 3, 4, 5]"),
+    ],
+)
+def test_optional_str(val: JsonType, expected: Optional[str]) -> None:
+    """
+
+
+    :param val: Value to convert
+    :param expected: Expected result of the test
+    """
+    assert optional_str(val) == expected


### PR DESCRIPTION
- Adds unit testing
- Includes a new `get_recipe_name()` convenience function to standardize the answering of the "what to call a recipe" problem
- Includes a simple `optional_str()` utility that forces string-evaluation unless a value is `None`.