### PR TITLE
`RecipeReader::get_value()` can now sub vars in strings

### DIFF
--- a/conda_recipe_manager/parser/_types.py
+++ b/conda_recipe_manager/parser/_types.py
@@ -116,7 +116,7 @@ class Regex:
     """
 
     # Pattern to detect Jinja variable names and functions
-    _JINJA_VAR_FUNCTION_PATTERN: Final[str] = r"[a-zA-Z_][a-zA-Z0-9_\|\'\"\(\)\, =\.\-]*"
+    _JINJA_VAR_FUNCTION_PATTERN: Final[str] = r"[a-zA-Z_][a-zA-Z0-9_\|\'\"\(\)\[\]\, =\.\-]*"
 
     ## Pre-process conversion tooling regular expressions ##
     # Finds `environ[]` used by a some recipe files. Requires a whitespace character to prevent matches with
@@ -165,10 +165,11 @@ class Regex:
     JINJA_V1_SUB: Final[re.Pattern[str]] = re.compile(r"\${{\s*" + _JINJA_VAR_FUNCTION_PATTERN + r"\s*}}")
 
     # All recognized JINJA functions are kept in a set for the convenience of trying to match against all of them.
-    # Group 1 contains the function name, Group 2 contains the arguments, if any.
+    # Group 1 contains the function or variable name, Group 2 contains the arguments, if any.
     JINJA_FUNCTION_LOWER: Final[re.Pattern[str]] = re.compile(r"\|\s*(lower)")
     JINJA_FUNCTION_UPPER: Final[re.Pattern[str]] = re.compile(r"\|\s*(upper)")
     JINJA_FUNCTION_REPLACE: Final[re.Pattern[str]] = re.compile(r"\|\s*(replace)\((.*)\)")
+    JINJA_FUNCTION_IDX_ACCESS: Final[re.Pattern[str]] = re.compile(r"(\w+)\[(\d+)\]")
     # `match()` is a JINJA function available in the V1 recipe format
     JINJA_FUNCTION_MATCH: Final[re.Pattern[str]] = re.compile(r"match\(.*,.*\)")
     JINJA_FUNCTIONS_SET: Final[set[re.Pattern[str]]] = {

--- a/conda_recipe_manager/parser/recipe_reader.py
+++ b/conda_recipe_manager/parser/recipe_reader.py
@@ -290,7 +290,7 @@ class RecipeReader(IsModifiable):
                     value = value.upper()
                 if idx_match:
                     idx = int(cast(str, idx_match.group(2)))
-                    # From our research, it looks string indexing on JINJA variables is almost exclusively used to get
+                    # From our research, it looks like string indexing on JINJA variables is almost exclusively used to get
                     # the first character in a string. If the index is out of bounds, we will default to the variable's
                     # value as a fall-back.
                     if 0 <= idx < len(value):

--- a/conda_recipe_manager/parser/recipe_reader.py
+++ b/conda_recipe_manager/parser/recipe_reader.py
@@ -224,7 +224,7 @@ class RecipeReader(IsModifiable):
 
     def _set_on_schema_version(self) -> tuple[int, re.Pattern[str]]:
         """
-        Helper function for `_render_jinja_vars()` that initialize `schema_version`-specific substitution details.
+        Helper function for `_render_jinja_vars()` that initializes `schema_version`-specific substitution details.
 
         :returns: The starting index and the regex pattern used to substitute V0 or V1 JINJA variables.
         """

--- a/conda_recipe_manager/parser/recipe_reader.py
+++ b/conda_recipe_manager/parser/recipe_reader.py
@@ -293,7 +293,7 @@ class RecipeReader(IsModifiable):
                     # From our research, it looks string indexing on JINJA variables is almost exclusively used to get
                     # the first character in a string. If the index is out of bounds, we will default to the variable's
                     # value as a fall-back.
-                    if 0 <= idx < len(key):
+                    if 0 <= idx < len(value):
                         value = value[idx]
                 s = s.replace(match, value)
             # $-Escaping the unresolved variable does a few things:

--- a/tests/parser/test_recipe_parser_deps.py
+++ b/tests/parser/test_recipe_parser_deps.py
@@ -136,16 +136,14 @@ def test_get_package_names_to_path(file: str, expected: dict[str, str]) -> None:
                         "cctools-and-ld64",
                         "/requirements/build/0",
                         DependencySection.BUILD,
-                        # TODO Future: Add support for `sub_vars` to render these common compiler variables and/or parse
-                        # the meaning.
-                        MatchSpec("gcc_{{ native_compiler_subdir }}"),
+                        MatchSpec("gcc_linux-64"),
                         SelectorParser("[linux]", SchemaVersion.V0),
                     ),
                     Dependency(
                         "cctools-and-ld64",
                         "/requirements/build/1",
                         DependencySection.BUILD,
-                        MatchSpec("gxx_{{ native_compiler_subdir }}"),
+                        MatchSpec("gxx_linux-64"),
                         SelectorParser("[linux]", SchemaVersion.V0),
                     ),
                     Dependency(
@@ -192,14 +190,14 @@ def test_get_package_names_to_path(file: str, expected: dict[str, str]) -> None:
                         "cctools",
                         "/requirements/build/0",
                         DependencySection.BUILD,
-                        MatchSpec("gcc_{{ native_compiler_subdir }}"),
+                        MatchSpec("gcc_linux-64"),
                         SelectorParser("[linux]", SchemaVersion.V0),
                     ),
                     Dependency(
                         "cctools",
                         "/requirements/build/1",
                         DependencySection.BUILD,
-                        MatchSpec("gxx_{{ native_compiler_subdir }}"),
+                        MatchSpec("gxx_linux-64"),
                         SelectorParser("[linux]", SchemaVersion.V0),
                     ),
                     Dependency(
@@ -245,14 +243,14 @@ def test_get_package_names_to_path(file: str, expected: dict[str, str]) -> None:
                         "ld64",
                         "/requirements/build/0",
                         DependencySection.BUILD,
-                        MatchSpec("gcc_{{ native_compiler_subdir }}"),
+                        MatchSpec("gcc_linux-64"),
                         SelectorParser("[linux]", SchemaVersion.V0),
                     ),
                     Dependency(
                         "ld64",
                         "/requirements/build/1",
                         DependencySection.BUILD,
-                        MatchSpec("gxx_{{ native_compiler_subdir }}"),
+                        MatchSpec("gxx_linux-64"),
                         SelectorParser("[linux]", SchemaVersion.V0),
                     ),
                     Dependency("ld64", "/requirements/build/2", DependencySection.BUILD, MatchSpec("autoconf"), None),

--- a/tests/parser/test_recipe_reader.py
+++ b/tests/parser/test_recipe_reader.py
@@ -583,6 +583,15 @@ def test_contains_value(file: str, path: str, expected: bool) -> None:
         ("simple-recipe_multiline_strings.yaml", "/about/description3", True, QUICK_FOX_SUB_CARROT),
         ("simple-recipe_multiline_strings.yaml", "/about/description4", True, QUICK_FOX_SUB_CARROT_PLUS),
         ("simple-recipe_multiline_strings.yaml", "/about/description5", True, QUICK_FOX_SUB_CARROT_MINUS),
+        ## types-toml.yaml ##
+        # TODO False case and whole source object w/ sub
+        # Regression: `{ name[0] }` could not be evaluated.
+        (
+            "types-toml.yaml",
+            "/source/url",
+            True,
+            "https://pypi.io/packages/source/t/types-toml/types-toml-0.10.8.6.tar.gz",
+        ),
         ## v1_simple-recipe.yaml ##
         ("v1_format/v1_simple-recipe.yaml", "/build/number", False, 0),
         ("v1_format/v1_simple-recipe.yaml", "/build/number/", False, 0),

--- a/tests/parser/test_recipe_reader.py
+++ b/tests/parser/test_recipe_reader.py
@@ -600,6 +600,28 @@ def test_contains_value(file: str, path: str, expected: bool) -> None:
                 "sha256": "6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2",
             },
         ),
+        ## sub_vars.yaml ##
+        (
+            "sub_vars.yaml",
+            "/package/name",
+            True,
+            "types-toml",
+        ),
+        (
+            "sub_vars.yaml",
+            "/source/url",
+            True,
+            "https://pypi.io/packages/source/t/TYPES-TOML/types-toml-6.tar.gz",
+        ),
+        (
+            "sub_vars.yaml",
+            "/source",
+            True,
+            {
+                "url": "https://pypi.io/packages/source/t/TYPES-TOML/types-toml-6.tar.gz",
+                "sha256": "6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2",
+            },
+        ),
         ## v1_simple-recipe.yaml ##
         ("v1_format/v1_simple-recipe.yaml", "/build/number", False, 0),
         ("v1_format/v1_simple-recipe.yaml", "/build/number/", False, 0),
@@ -712,6 +734,28 @@ def test_contains_value(file: str, path: str, expected: bool) -> None:
             True,
             {
                 "url": "https://pypi.io/packages/source/t/types-toml/types-toml-0.10.8.6.tar.gz",
+                "sha256": "6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2",
+            },
+        ),
+        ## v1_sub_vars.yaml ##
+        (
+            "v1_format/v1_sub_vars.yaml",
+            "/package/name",
+            True,
+            "types-toml",
+        ),
+        (
+            "v1_format/v1_sub_vars.yaml",
+            "/source/url",
+            True,
+            "https://pypi.io/packages/source/t/TYPES-TOML/types-toml-6.tar.gz",
+        ),
+        (
+            "v1_format/v1_sub_vars.yaml",
+            "/source",
+            True,
+            {
+                "url": "https://pypi.io/packages/source/t/TYPES-TOML/types-toml-6.tar.gz",
                 "sha256": "6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2",
             },
         ),

--- a/tests/parser/test_recipe_reader.py
+++ b/tests/parser/test_recipe_reader.py
@@ -584,13 +584,21 @@ def test_contains_value(file: str, path: str, expected: bool) -> None:
         ("simple-recipe_multiline_strings.yaml", "/about/description4", True, QUICK_FOX_SUB_CARROT_PLUS),
         ("simple-recipe_multiline_strings.yaml", "/about/description5", True, QUICK_FOX_SUB_CARROT_MINUS),
         ## types-toml.yaml ##
-        # TODO False case and whole source object w/ sub
         # Regression: `{ name[0] }` could not be evaluated.
         (
             "types-toml.yaml",
             "/source/url",
             True,
             "https://pypi.io/packages/source/t/types-toml/types-toml-0.10.8.6.tar.gz",
+        ),
+        (
+            "types-toml.yaml",
+            "/source",
+            True,
+            {
+                "url": "https://pypi.io/packages/source/t/types-toml/types-toml-0.10.8.6.tar.gz",
+                "sha256": "6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2",
+            },
         ),
         ## v1_simple-recipe.yaml ##
         ("v1_format/v1_simple-recipe.yaml", "/build/number", False, 0),
@@ -689,6 +697,23 @@ def test_contains_value(file: str, path: str, expected: bool) -> None:
                 "This types-toml is silly",
                 "last",
             ],
+        ),
+        ## v1_types-toml.yaml ##
+        # Regression: `{ name[0] }` could not be evaluated.
+        (
+            "v1_format/v1_types-toml.yaml",
+            "/source/url",
+            True,
+            "https://pypi.io/packages/source/t/types-toml/types-toml-0.10.8.6.tar.gz",
+        ),
+        (
+            "v1_format/v1_types-toml.yaml",
+            "/source",
+            True,
+            {
+                "url": "https://pypi.io/packages/source/t/types-toml/types-toml-0.10.8.6.tar.gz",
+                "sha256": "6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2",
+            },
         ),
         ## multi-output.yaml ##
         ("multi-output.yaml", "/outputs/0/build/run_exports/0", False, "bar"),

--- a/tests/parser/test_recipe_reader.py
+++ b/tests/parser/test_recipe_reader.py
@@ -733,6 +733,12 @@ def test_contains_value(file: str, path: str, expected: bool) -> None:
         #        "test": {"commands": ["db_archive -m hello"]},
         #    },
         # ),
+        ## v1_multi-output.yaml ##
+        ("v1_format/v1_multi-output.yaml", "/outputs/0/requirements/run_exports/0", False, "bar"),
+        ("v1_format/v1_multi-output.yaml", "/outputs/0/requirements/run_exports", False, ["bar"]),
+        # TODO FIX: This case
+        # ("v1_format/v1_multi-output.yaml", "/outputs/0/build", False, None),
+        ("v1_format/v1_multi-output.yaml", "/outputs/0/requirements", False, {"run_exports": ["bar"]}),
     ],
 )
 def test_get_value(file: str, path: str, sub_vars: bool, expected: JsonType) -> None:

--- a/tests/test_aux_files/sub_vars.yaml
+++ b/tests/test_aux_files/sub_vars.yaml
@@ -1,0 +1,48 @@
+{% set name = "TYPES-toml" %}
+{% set version = "0.10.8.6" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0]|lower }}/{{ name|upper }}/{{ name[42] | lower}}-{{ version[7] }}.tar.gz
+  sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
+
+build:
+  number: 0
+  skip: true  # [py<37]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - setuptools
+    - wheel
+    - pip
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - types
+  requires:
+    - pip
+  commands:
+    - pip check
+    - test -f $SP_DIR/toml-stubs/__init__.pyi  # [unix]
+
+about:
+  home: https://github.com/python/typeshed
+  summary: Contains edge cases for `RecipeReader::get_value(sub_vars=True)`
+  description: Contains edge cases for `RecipeReader::get_value(sub_vars=True)`
+  license: Apache-2.0 AND MIT
+  license_file: LICENSE
+  license_family: OTHER
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://pypi.org/project/types-toml/
+
+extra:
+  recipe-maintainers:
+    - fhoehle
+    - conda-forge/mypy

--- a/tests/test_aux_files/v1_format/v1_sub_vars.yaml
+++ b/tests/test_aux_files/v1_format/v1_sub_vars.yaml
@@ -1,0 +1,54 @@
+schema_version: 1
+
+context:
+  name: TYPES-toml
+  version: 0.10.8.6
+
+package:
+  name: ${{ name|lower }}
+  version: ${{ version }}
+
+source:
+  url: https://pypi.io/packages/source/${{ name[0]|lower }}/${{ name|upper }}/${{ name[42] | lower}}-${{ version[7] }}.tar.gz
+  sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
+
+build:
+  number: 0
+  skip: match(python, "<3.7")
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - setuptools
+    - wheel
+    - pip
+    - python
+  run:
+    - python
+
+tests:
+  - python:
+      imports:
+        - types
+      pip_check: true
+  - requirements:
+      run:
+        - pip
+    script:
+      - if: unix
+        then: test -f $SP_DIR/toml-stubs/__init__.pyi
+
+about:
+  summary: Contains edge cases for `RecipeReader::get_value(sub_vars=True)`
+  description: Contains edge cases for `RecipeReader::get_value(sub_vars=True)`
+  license: Apache-2.0 AND MIT
+  license_file: LICENSE
+  homepage: https://github.com/python/typeshed
+  repository: https://github.com/python/typeshed
+  documentation: https://pypi.org/project/types-toml/
+
+extra:
+  recipe-maintainers:
+    - fhoehle
+    - conda-forge/mypy
+


### PR DESCRIPTION
- Adds support for the access operator (on strings) and the `upper` JINJA
  function
- Fixes several issues with JINJA variable subsitutions
- General code clean-up
- Updates tests with improvements