### PR TITLE
Addresses nuance with pyfakefs and pathlib

### DIFF
--- a/tests/commands/test_convert.py
+++ b/tests/commands/test_convert.py
@@ -5,7 +5,7 @@
 from click.testing import CliRunner
 
 from conda_recipe_manager.commands.convert import convert
-from tests.file_loading import TEST_FILES_PATH, load_file
+from tests.file_loading import get_test_path, load_file
 from tests.smoke_testing import assert_cli_usage
 
 
@@ -21,7 +21,7 @@ def test_only_allow_v0_recipes() -> None:
     Ensures the user gets an error when a V1 recipe is provided to the conversion script.
     """
     runner = CliRunner()
-    result = runner.invoke(convert, [f"{TEST_FILES_PATH}/v1_format/v1_simple-recipe.yaml"])
+    result = runner.invoke(convert, [str(get_test_path() / "v1_format/v1_simple-recipe.yaml")])
     assert result.exit_code != 0
     assert result.output.startswith("ILLEGAL OPERATION:")
 
@@ -31,7 +31,7 @@ def test_convert_single_file() -> None:
     Ensures the user gets an error when a V1 recipe is provided to the conversion script.
     """
     runner = CliRunner(mix_stderr=False)
-    result = runner.invoke(convert, [f"{TEST_FILES_PATH}/simple-recipe.yaml"])
+    result = runner.invoke(convert, [str(get_test_path() / "simple-recipe.yaml")])
     # This recipe has warnings
     assert result.exit_code == 100
     # `crm convert` prints an additional newline

--- a/tests/fetcher/test_artifact_fetcher.py
+++ b/tests/fetcher/test_artifact_fetcher.py
@@ -14,7 +14,7 @@ from conda_recipe_manager.fetcher.exceptions import FetchUnsupportedError
 from conda_recipe_manager.fetcher.git_artifact_fetcher import GitArtifactFetcher
 from conda_recipe_manager.fetcher.http_artifact_fetcher import HttpArtifactFetcher
 from conda_recipe_manager.parser.recipe_reader import RecipeReader
-from tests.file_loading import TEST_FILES_PATH, load_recipe
+from tests.file_loading import get_test_path, load_recipe
 
 
 @pytest.mark.parametrize(
@@ -43,7 +43,7 @@ def test_from_recipe_ignore_unsupported(
     :param file: File to work against
     :param expected: Expected list of classes to match the returned list.
     """
-    request.getfixturevalue("fs").add_real_file(TEST_FILES_PATH / file)  # type: ignore[misc]
+    request.getfixturevalue("fs").add_real_file(get_test_path() / file)  # type: ignore[misc]
     recipe = load_recipe(file, RecipeReader)
 
     fetcher_list: Final[list[BaseArtifactFetcher]] = from_recipe(recipe, True)
@@ -68,7 +68,7 @@ def test_from_recipe_throws_on_unsupported(file: str, request: pytest.FixtureReq
 
     :param file: File to work against
     """
-    request.getfixturevalue("fs").add_real_file(TEST_FILES_PATH / file)  # type: ignore[misc]
+    request.getfixturevalue("fs").add_real_file(get_test_path() / file)  # type: ignore[misc]
     recipe = load_recipe(file, RecipeReader)
 
     with pytest.raises(FetchUnsupportedError):
@@ -91,7 +91,7 @@ def test_from_recipe_does_not_throw_on_ignore_unsupported(file: str, request: py
 
     :param file: File to work against
     """
-    request.getfixturevalue("fs").add_real_file(TEST_FILES_PATH / file)  # type: ignore[misc]
+    request.getfixturevalue("fs").add_real_file(get_test_path() / file)  # type: ignore[misc]
     recipe = load_recipe(file, RecipeReader)
 
     assert not from_recipe(recipe, True)

--- a/tests/fetcher/test_http_artifact_fetcher.py
+++ b/tests/fetcher/test_http_artifact_fetcher.py
@@ -14,7 +14,7 @@ from pyfakefs.fake_filesystem import FakeFilesystem
 
 from conda_recipe_manager.fetcher.exceptions import FetchError, FetchRequiredError
 from conda_recipe_manager.fetcher.http_artifact_fetcher import ArtifactArchiveType, HttpArtifactFetcher
-from tests.file_loading import TEST_FILES_PATH
+from tests.file_loading import get_test_path
 from tests.http_mocking import MockHttpStreamResponse
 
 
@@ -97,7 +97,7 @@ def test_fetch(
     :param request: Pytest fixture request object.
     """
     # Make the test directory accessible to the HTTP mocker
-    request.getfixturevalue("fs").add_real_directory(TEST_FILES_PATH / "archive_files")  # type: ignore[misc]
+    request.getfixturevalue("fs").add_real_directory(get_test_path() / "archive_files")  # type: ignore[misc]
 
     http_fetcher = cast(HttpArtifactFetcher, request.getfixturevalue(http_fixture))
     with patch("requests.get", new=mock_requests_get):
@@ -137,7 +137,7 @@ def test_fetch_http_failure(fs: FakeFilesystem, http_fetcher_failure: HttpArtifa
     :param fs: pyfakefs fixture used to replace the file system
     :param http_fetcher_failure: HttpArtifactFetcher test fixture
     """
-    fs.add_real_directory(TEST_FILES_PATH / "archive_files")
+    fs.add_real_directory(get_test_path() / "archive_files")
 
     with pytest.raises(FetchError) as e:
         with patch("requests.get", new=mock_requests_get):
@@ -162,7 +162,7 @@ def test_get_path_to_source_code(http_fixture: str, expected_src: str, request: 
     :param request: Pytest fixture request object.
     """
     # Make the test directory accessible to the HTTP mocker
-    request.getfixturevalue("fs").add_real_directory(TEST_FILES_PATH / "archive_files")  # type: ignore[misc]
+    request.getfixturevalue("fs").add_real_directory(get_test_path() / "archive_files")  # type: ignore[misc]
 
     http_fetcher = cast(HttpArtifactFetcher, request.getfixturevalue(http_fixture))
     with patch("requests.get", new=mock_requests_get):
@@ -202,7 +202,7 @@ def test_get_archive_sha256(http_fixture: str, expected_hash: str, request: pyte
     :param request: Pytest fixture request object.
     """
     # Make the test directory accessible to the HTTP mocker
-    request.getfixturevalue("fs").add_real_directory(TEST_FILES_PATH / "archive_files")  # type: ignore[misc]
+    request.getfixturevalue("fs").add_real_directory(get_test_path() / "archive_files")  # type: ignore[misc]
 
     http_fetcher = cast(HttpArtifactFetcher, request.getfixturevalue(http_fixture))
     with patch("requests.get", new=mock_requests_get):
@@ -242,7 +242,7 @@ def test_get_archive_type(
     :param request: Pytest fixture request object.
     """
     # Make the test directory accessible to the HTTP mocker
-    request.getfixturevalue("fs").add_real_directory(TEST_FILES_PATH / "archive_files")  # type: ignore[misc]
+    request.getfixturevalue("fs").add_real_directory(get_test_path() / "archive_files")  # type: ignore[misc]
 
     http_fetcher = cast(HttpArtifactFetcher, request.getfixturevalue(http_fixture))
     with patch("requests.get", new=mock_requests_get):

--- a/tests/file_loading.py
+++ b/tests/file_loading.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from typing import Final, Type, TypeVar, cast
 
@@ -14,11 +15,27 @@ from conda_recipe_manager.parser.recipe_parser_deps import RecipeParserDeps
 from conda_recipe_manager.parser.recipe_reader import RecipeReader
 from conda_recipe_manager.types import JsonType
 
-# Path to supplementary files used in test cases
-TEST_FILES_PATH: Final[Path] = Path(__file__).parent / "test_aux_files"
+# Private string, calculated once, containing the path to the test files.
+_TEST_FILES_PATH_STR: Final[str] = f"{os.path.dirname(__file__)}/test_aux_files"
 
 # Generic Type for recipe-parsing classes
 R = TypeVar("R", bound=RecipeReader)
+
+
+def get_test_path() -> Path:
+    """
+    Returns a path object that points to the directory containing all auxillary testing files. We no longer store this
+    value as a constant by design. We cannot guarantee the proper construction of a global constants Path variable
+    in tests that use `pyfakefs`. So instead, this function aims to provide the convenience of using `pathlib` while
+    simplifying the `pyfakefs` nuance.
+
+    See this documentation for more details:
+    https://pytest-pyfakefs.readthedocs.io/en/latest/troubleshooting.html#pathlib-path-objects-created-outside-of-tests
+
+
+    :returns: Path object that points to where all additional test files are stored.
+    """
+    return Path(_TEST_FILES_PATH_STR)
 
 
 def load_file(file: Path | str) -> str:
@@ -29,7 +46,7 @@ def load_file(file: Path | str) -> str:
     :param file: Filename/relative path of the file to read
     :returns: Text from the file
     """
-    return Path(TEST_FILES_PATH / file).read_text(encoding="utf-8")
+    return (get_test_path() / file).read_text(encoding="utf-8")
 
 
 def load_recipe(file_name: Path | str, recipe_parser: Type[R]) -> R:
@@ -69,7 +86,7 @@ def load_cbc(file_name: Path | str) -> CbcParser:
     :param file_name: File name of the test CBC file to load
     :returns: RecipeParser instance, based on the file
     """
-    cbc: Final[str] = load_file(TEST_FILES_PATH / "cbc_files" / file_name)
+    cbc: Final[str] = load_file(get_test_path() / "cbc_files" / file_name)
     return CbcParser(cbc)
 
 

--- a/tests/grapher/test_recipe_graph_from_disk.py
+++ b/tests/grapher/test_recipe_graph_from_disk.py
@@ -4,17 +4,18 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Final
 
 from conda_recipe_manager.grapher.recipe_graph_from_disk import RecipeGraphFromDisk
-from tests.file_loading import TEST_FILES_PATH
+from tests.file_loading import get_test_path
 
 
 def test_construct_rg_from_disk() -> None:
     """
     Simple smoke test that validates constructing a RecipeGraphFromDisk object from a small test directory
     """
-    path: Final[str] = f"{TEST_FILES_PATH}/rg_from_disk_test"
+    path: Final[Path] = get_test_path() / "rg_from_disk_test"
     # Using all available CPUs WHILE running tests with xdist causes some stability issues. When running tests,
     # pytest-cov will report coverage file corruption AND this test will hang for a few seconds.
     rg = RecipeGraphFromDisk(path, cpu_count=1)

--- a/tests/http_mocking.py
+++ b/tests/http_mocking.py
@@ -10,7 +10,7 @@ from typing import Iterable
 import requests
 
 from conda_recipe_manager.types import JsonType, SentinelType
-from tests.file_loading import TEST_FILES_PATH, load_file, load_json_file
+from tests.file_loading import get_test_path, load_file, load_json_file
 
 
 class MockHttpResponse:
@@ -107,14 +107,15 @@ class MockHttpStreamResponse(MockHttpResponse):
         """
         Constructs a mocked HTTP response that streams data.
 
-        NOTE: `fs.add_real_directory(TEST_FILES_PATH)` must be called before this mocker is used in order to
+        NOTE: `fs.add_real_directory()` must be called before this mocker is used in order to ensure
+        the file is available to the fake file system.
 
         :param status_code: HTTP status code to return
         :param file: Path to file to load data from.
         :param content_type: (Optional) `content-type` header string
         """
         super().__init__(status_code, content_type)
-        self._file_obj = open(TEST_FILES_PATH / file, "rb")  # pylint: disable=consider-using-with
+        self._file_obj = open(get_test_path() / file, "rb")  # pylint: disable=consider-using-with
 
         # Mock `iter_content()` by passing the buck to `read()`
         def _mock_iter_content(chunk_size: int) -> Iterable[bytes]:

--- a/tests/utils/cryptography/test_hashing.py
+++ b/tests/utils/cryptography/test_hashing.py
@@ -10,7 +10,7 @@ from typing import Callable
 import pytest
 
 from conda_recipe_manager.utils.cryptography.hashing import hash_file, hash_str
-from tests.file_loading import TEST_FILES_PATH, load_file
+from tests.file_loading import get_test_path, load_file
 
 
 @pytest.mark.parametrize(
@@ -33,7 +33,7 @@ def test_hash_file(file: str, algo: str | Callable[[], hashlib._Hash], expected:
     :param algo: Target algorithm
     :param expected: Expected value to return
     """
-    assert hash_file(TEST_FILES_PATH / file, algo) == expected
+    assert hash_file(get_test_path() / file, algo) == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #151 by deprecating the global `TEST_FILE_PATHS` constant in favor of a function that generates the same `Path` object.

Although this is a more expensive approach, it does mean that every test has the conveniences offered by `pathlib` without having to worry about how the `Path` object is constructed. 

In other words:
Calling `get_test_path()` will create an object instance that refers to either the real or the fake file system, depending on the inclusion of the `fs` fixture.