### PR TITLE
Test the `MessageTable` class

### DIFF
--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -4,27 +4,62 @@
 
 from __future__ import annotations
 
+import pytest
+
 from conda_recipe_manager.types import MessageCategory, MessageTable
 
 
-def test_message_table_add_retrieve_and_clear() -> None:
+@pytest.mark.parametrize(
+    "message,content,output",
+    [
+        (MessageCategory.WARNING, "Test warning message", "0 errors and 1 warning were found."),
+        (MessageCategory.ERROR, "Test error message", "1 error and 0 warnings were found."),
+    ],
+)
+def test_message_table_add(message: MessageCategory, content: str, output: str) -> None:
+    """
+    Tests the addition of messages to the message table and checks output of warnings and errors contained
+    in the messaging object.
+
+    param message: Message category
+    param content: Message content
+    param output: Expected output
+    """
     message_table = MessageTable()
-    message_table.add_message(MessageCategory.ERROR, "Test error message")
-    message_table.add_message(MessageCategory.WARNING, "Test warning message")
+    message_table.add_message(message, content)
+    assert message_table.get_totals_message() == output
 
-    assert message_table.get_totals_message() == "1 error and 1 warning were found."
 
-    assert message_table.get_message_count(MessageCategory.EXCEPTION) == 0
-    assert message_table.get_message_count(MessageCategory.ERROR) == 1
-    assert message_table.get_message_count(MessageCategory.WARNING) == 1
+@pytest.mark.parametrize(
+    "message,content,count",
+    [
+        (MessageCategory.EXCEPTION, "Test exception message", 1),
+        (MessageCategory.WARNING, "Test warning message", 1),
+        (MessageCategory.ERROR, "Test error message", 1),
+    ],
+)
+def test_message_get_count(message: MessageCategory, content: str, count: int) -> None:
+    """
+    Tests the addition of messages to the message table and checks the count of warnings and
+    errors contained in the messaging object.
 
-    message_table.add_message(MessageCategory.ERROR, "Error message 2")
+    param message: Message category
+    param content: Message content
+    param count: Expected count
+    """
+    message_table = MessageTable()
 
-    assert message_table.get_message_count(MessageCategory.EXCEPTION) == 0
-    assert message_table.get_message_count(MessageCategory.ERROR) == 2
-    assert message_table.get_message_count(MessageCategory.WARNING) == 1
+    message_table.add_message(message, content)
+    assert message_table.get_message_count(message) == count
 
-    assert message_table.get_totals_message() == "2 errors and 1 warning were found."
+
+def test_message_table_clear() -> None:
+    """
+    Tests whether or not the message table properly clears all messages.
+    """
+    message_table = MessageTable()
+    message_table.add_message(MessageCategory.ERROR, "Test warning message")
+    message_table.add_message(MessageCategory.WARNING, "Test error message")
 
     message_table.clear_messages()
     assert message_table.get_message_count(MessageCategory.EXCEPTION) == 0

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,0 +1,33 @@
+"""
+:Description: Unit tests for the types module
+"""
+
+from __future__ import annotations
+
+from conda_recipe_manager.types import MessageCategory, MessageTable
+
+
+def test_message_table_add_retrieve_and_clear() -> None:
+    message_table = MessageTable()
+    message_table.add_message(MessageCategory.ERROR, "Test error message")
+    message_table.add_message(MessageCategory.WARNING, "Test warning message")
+
+    assert message_table.get_totals_message() == "1 error and 1 warning were found."
+
+    assert message_table.get_message_count(MessageCategory.EXCEPTION) == 0
+    assert message_table.get_message_count(MessageCategory.ERROR) == 1
+    assert message_table.get_message_count(MessageCategory.WARNING) == 1
+
+    message_table.add_message(MessageCategory.ERROR, "Error message 2")
+
+    assert message_table.get_message_count(MessageCategory.EXCEPTION) == 0
+    assert message_table.get_message_count(MessageCategory.ERROR) == 2
+    assert message_table.get_message_count(MessageCategory.WARNING) == 1
+
+    assert message_table.get_totals_message() == "2 errors and 1 warning were found."
+
+    message_table.clear_messages()
+    assert message_table.get_message_count(MessageCategory.EXCEPTION) == 0
+    assert message_table.get_message_count(MessageCategory.ERROR) == 0
+    assert message_table.get_message_count(MessageCategory.WARNING) == 0
+    assert message_table.get_totals_message() == ""

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -60,8 +60,8 @@ def test_message_table_add(messages_and_contents: list[tuple[MessageCategory, st
     Tests the addition of messages to the message table and checks the expected output of warnings and errors
     contained in the messaging object.
 
-    param messages_and_contents: Message category and message content
-    param expected: Expected output
+    :param messages_and_contents: Message category and message content
+    :param expected: Expected output
     """
     message_table = MessageTable()
     for category, content in messages_and_contents:
@@ -98,8 +98,8 @@ def test_message_get_count(
     Tests the addition of messages to the message table and checks the count of warnings and
     errors contained in the messaging object.
 
-    param messages_and_contents: Message category and message content
-    param count: Expected count
+    :param messages_and_contents: Message category and message content
+    :param count: Expected count
     """
     message_table = MessageTable()
 
@@ -138,8 +138,8 @@ def test_message_table_clear(
     """
     Tests whether or not the message table properly clears all messages.
 
-    param messages_and_contents: Message category and message content
-    param count: Expected count
+    :param messages_and_contents: Message category and message content
+    :param count: Expected count
     """
     message_table = MessageTable()
     for category, content in messages_and_contents:


### PR DESCRIPTION
Resolves #177 

The new unit test aims to cover all of the methods contained in the [`MessageTable` class in `types.py`](https://github.com/conda-incubator/conda-recipe-manager/blob/main/conda_recipe_manager/types.py#L84-L159), which includes `add_message()`, `get_messages()`, `get_message_count()`, `get_totals_message()`, and `clear_messages()`.

