### PR TITLE
Removes conda-forge channel

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
   - id: black
     args: [--line-length=120]
 - repo: https://github.com/PyCQA/pylint
-  rev: v3.2.2
+  rev: v3.2.7
   hooks:
   - id: pylint
     args: ["--rcfile=.pylintrc"]

--- a/environment.yaml
+++ b/environment.yaml
@@ -11,9 +11,9 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-xdist
-  - conda-forge::pyfakefs
+  - pyfakefs
   # Match version with .pre-commit-config.yaml to ensure consistent rules with `make lint`.
-  - conda-forge::pylint ==3.2.2
+  - pylint ==3.2.7
   - pip
   - click >=8.1.7
   - conda


### PR DESCRIPTION
Defaults now includes newer versions of the two packages we were relying on `conda-forge` for.

Some say this will fix a rare issue and that code is non-deterministic. All we know is he's called _The Stig_.