### PR TITLE
Add "Set the `/build/number` back to 0" logic to bump-recipe

### DIFF
--- a/conda_recipe_manager/commands/bump_recipe.py
+++ b/conda_recipe_manager/commands/bump_recipe.py
@@ -15,11 +15,50 @@ from conda_recipe_manager.commands.utils.types import ExitCode
 from conda_recipe_manager.parser.recipe_parser import RecipeParser
 from conda_recipe_manager.types import JsonPatchType
 
-
 # TODO Improve. In order for `click` to play nice with `pyfakefs`, we set `path_type=str` and delay converting to a
 # `Path` instance. This is caused by how `click` uses decorators. See these links for more detail:
 # - https://pytest-pyfakefs.readthedocs.io/en/latest/troubleshooting.html#pathlib-path-objects-created-outside-of-tests
 # - https://github.com/pytest-dev/pyfakefs/discussions/605
+
+
+def get_required_patch_blob(recipe_parser: RecipeParser, build_num: bool) -> JsonPatchType:
+    """
+    Returns the required JSON Patch Blob
+
+    :recipe_parser: RecipeParser object
+    :build_num: `build_num` boolean flag
+    :returns: A JSON Patch blob to add or modify the build number
+    """
+
+    # try to get "build" key from the recipe, exit if not found
+    try:
+        recipe_parser.get_value("/build")
+    except KeyError:
+        print_err("`/build` key could not be found in the recipe.")
+        sys.exit(ExitCode.ILLEGAL_OPERATION)
+
+    # if build key is found, try to get build/number key
+    # in case of `build_num` set to false, `build/number` key will be added and set to zero
+    # when `build_num` is set to true, throw error and sys.exit()
+    try:
+        build_number = recipe_parser.get_value("/build/number")
+        required_patch_blob = cast(JsonPatchType, {"op": "replace", "path": "/build/number", "value": 0})
+        if build_num:
+            if not isinstance(build_number, int):
+                print_err("Build number is not an integer.")
+                sys.exit(ExitCode.ILLEGAL_OPERATION)
+            required_patch_blob = cast(
+                JsonPatchType, {"op": "replace", "path": "/build/number", "value": build_number + 1}
+            )
+    except KeyError:
+        required_patch_blob = cast(JsonPatchType, {"op": "add", "path": "/build/number", "value": 0})
+        if build_num:
+            print_err("`/build/number` key could not be found in the recipe.")
+            sys.exit(ExitCode.ILLEGAL_OPERATION)
+
+    return required_patch_blob
+
+
 @click.command(short_help="Bumps a recipe file to a new version.")
 @click.argument("recipe_file_path", type=click.Path(exists=True, path_type=str))
 @click.option(
@@ -45,23 +84,11 @@ def bump_recipe(recipe_file_path: str, build_num: bool) -> None:
         print_err("An error occurred while parsing the recipe file contents.")
         sys.exit(ExitCode.PARSE_EXCEPTION)
 
-    if build_num:
-        try:
-            build_number = recipe_parser.get_value("/build/number")
-        except KeyError:
-            print_err("`/build/number` key could not be found in the recipe.")
-            sys.exit(ExitCode.ILLEGAL_OPERATION)
+    required_patch_blob = get_required_patch_blob(recipe_parser, build_num)
 
-        if not isinstance(build_number, int):
-            print_err("Build number is not an integer.")
-            sys.exit(ExitCode.ILLEGAL_OPERATION)
+    if not recipe_parser.patch(required_patch_blob):
+        print_err(f"Couldn't perform the patch: {required_patch_blob}.")
+        sys.exit(ExitCode.PARSE_EXCEPTION)
 
-        required_patch_blob = cast(JsonPatchType, {"op": "replace", "path": "/build/number", "value": build_number + 1})
-
-        if not recipe_parser.patch(required_patch_blob):
-            print_err(f"Couldn't perform the patch: {required_patch_blob}.")
-            sys.exit(ExitCode.PARSE_EXCEPTION)
-
-        Path(recipe_file_path).write_text(recipe_parser.render(), encoding="utf-8")
-        sys.exit(ExitCode.SUCCESS)
-    print_err("Sorry, the default bump behaviour has not been implemented yet.")
+    Path(recipe_file_path).write_text(recipe_parser.render(), encoding="utf-8")
+    sys.exit(ExitCode.SUCCESS)

--- a/conda_recipe_manager/commands/bump_recipe.py
+++ b/conda_recipe_manager/commands/bump_recipe.py
@@ -40,6 +40,8 @@ def get_required_patch_blob(recipe_parser: RecipeParser, build_num: bool) -> Jso
     # if build key is found, try to get build/number key
     # in case of `build_num` set to false, `build/number` key will be added and set to zero
     # when `build_num` is set to true, throw error and sys.exit()
+
+    # TODO use contains_value() instead of try catch
     try:
         build_number = recipe_parser.get_value("/build/number")
         required_patch_blob = cast(JsonPatchType, {"op": "replace", "path": "/build/number", "value": 0})

--- a/conda_recipe_manager/commands/bump_recipe.py
+++ b/conda_recipe_manager/commands/bump_recipe.py
@@ -21,7 +21,7 @@ from conda_recipe_manager.types import JsonPatchType
 # - https://github.com/pytest-dev/pyfakefs/discussions/605
 
 
-def get_required_patch_blob(recipe_parser: RecipeParser, build_num: bool) -> JsonPatchType:
+def _get_required_patch_blob(recipe_parser: RecipeParser, increment_build_num: bool) -> JsonPatchType:
     """
     Returns the required JSON Patch Blob
 
@@ -30,35 +30,31 @@ def get_required_patch_blob(recipe_parser: RecipeParser, build_num: bool) -> Jso
     :returns: A JSON Patch blob to add or modify the build number
     """
 
-    # try to get "build" key from the recipe, exit if not found
+    # Try to get "build" key from the recipe, exit if not found
     try:
         recipe_parser.get_value("/build")
     except KeyError:
         print_err("`/build` key could not be found in the recipe.")
         sys.exit(ExitCode.ILLEGAL_OPERATION)
 
-    # if build key is found, try to get build/number key
-    # in case of `build_num` set to false, `build/number` key will be added and set to zero
-    # when `build_num` is set to true, throw error and sys.exit()
+    # If build key is found, try to get build/number key in case of `build_num` set to false, `build/number` key will be
+    # added and set to zero when `build_num` is set to true, throw error and sys.exit()
 
     # TODO use contains_value() instead of try catch
     try:
         build_number = recipe_parser.get_value("/build/number")
-        required_patch_blob = cast(JsonPatchType, {"op": "replace", "path": "/build/number", "value": 0})
-        if build_num:
+        if increment_build_num:
             if not isinstance(build_number, int):
                 print_err("Build number is not an integer.")
                 sys.exit(ExitCode.ILLEGAL_OPERATION)
-            required_patch_blob = cast(
-                JsonPatchType, {"op": "replace", "path": "/build/number", "value": build_number + 1}
-            )
+
+            return cast(JsonPatchType, {"op": "replace", "path": "/build/number", "value": build_number + 1})
     except KeyError:
-        required_patch_blob = cast(JsonPatchType, {"op": "add", "path": "/build/number", "value": 0})
-        if build_num:
+        if increment_build_num:
             print_err("`/build/number` key could not be found in the recipe.")
             sys.exit(ExitCode.ILLEGAL_OPERATION)
 
-    return required_patch_blob
+    return cast(JsonPatchType, {"op": "add", "path": "/build/number", "value": 0})
 
 
 @click.command(short_help="Bumps a recipe file to a new version.")
@@ -86,7 +82,7 @@ def bump_recipe(recipe_file_path: str, build_num: bool) -> None:
         print_err("An error occurred while parsing the recipe file contents.")
         sys.exit(ExitCode.PARSE_EXCEPTION)
 
-    required_patch_blob = get_required_patch_blob(recipe_parser, build_num)
+    required_patch_blob = _get_required_patch_blob(recipe_parser, build_num)
 
     if not recipe_parser.patch(required_patch_blob):
         print_err(f"Couldn't perform the patch: {required_patch_blob}.")

--- a/conda_recipe_manager/commands/bump_recipe.py
+++ b/conda_recipe_manager/commands/bump_recipe.py
@@ -25,8 +25,8 @@ def _get_required_patch_blob(recipe_parser: RecipeParser, increment_build_num: b
     """
     Returns the required JSON Patch Blob
 
-    :recipe_parser: RecipeParser object
-    :build_num: `build_num` boolean flag
+    :param recipe_parser: Recipe file to update.
+    :param increment_build_num: Increments the `/build/number` field by 1 if set to `True`. Otherwise resets to 0.
     :returns: A JSON Patch blob to add or modify the build number
     """
 

--- a/conda_recipe_manager/parser/recipe_reader.py
+++ b/conda_recipe_manager/parser/recipe_reader.py
@@ -821,6 +821,7 @@ class RecipeReader(IsModifiable):
         """
         Determines if a value (via a path) is contained in this recipe. This also allows the caller to determine if a
         path exists.
+
         :param path: JSON patch (RFC 6902)-style path to a value.
         :returns: True if the path exists. False otherwise.
         """

--- a/tests/commands/test_bump_recipe.py
+++ b/tests/commands/test_bump_recipe.py
@@ -39,7 +39,7 @@ def test_bump_recipe_cli(
     fs: FakeFilesystem, recipe_file: str, increment_build_num: bool, expected_recipe_file: str
 ) -> None:
     """
-    Test that the build number is successfully reset to 0.
+    Test that the recipe file is successfully updated/bumped.
 
     :param fs: `pyfakefs` Fixture used to replace the file system
     """
@@ -82,7 +82,7 @@ def test_bump_cli_build_number_key_missing(fs: FakeFilesystem) -> None:
     assert result.exit_code == ExitCode.SUCCESS
 
 
-def test_bump_cli_build_num_not_int(fs: FakeFilesystem) -> None:
+def test_bump_cli_build_number_not_int(fs: FakeFilesystem) -> None:
     """
     Test that the command fails gracefully case when the build number is not an integer,
     and we are trying to increment it.
@@ -99,7 +99,7 @@ def test_bump_cli_build_num_not_int(fs: FakeFilesystem) -> None:
     assert result.exit_code == ExitCode.ILLEGAL_OPERATION
 
 
-def test_bump_cli_build_numb_key_not_found(fs: FakeFilesystem) -> None:
+def test_bump_cli_build_number_key_not_found(fs: FakeFilesystem) -> None:
     """
     Test that the command fails gracefully when the build number key is missing and we try to increment it's value.
 

--- a/tests/commands/test_bump_recipe.py
+++ b/tests/commands/test_bump_recipe.py
@@ -50,6 +50,27 @@ def test_bump_recipe_cli(fs: FakeFilesystem, recipe_file: str, expected_recipe_f
     assert result.exit_code == ExitCode.SUCCESS
 
 
+def test_bump_cli_build_number_key_missing(fs: FakeFilesystem) -> None:
+    """
+    Test that a `build: number:` key is added and set to 0 when it's missing.
+
+    :param fs: `pyfakefs` Fixture used to replace the file system
+    """
+    runner = CliRunner()
+    fs.add_real_directory(get_test_path(), read_only=False)
+
+    recipe_file_path = get_test_path() / "bump_recipe/no_build_num.yaml"
+    expected_recipe_file_path = get_test_path() / "bump_recipe/build_num_added.yaml"
+
+    result = runner.invoke(bump_recipe.bump_recipe, [str(recipe_file_path)])
+
+    parser = load_recipe(recipe_file_path, RecipeParser)
+    expected_parser = load_recipe(expected_recipe_file_path, RecipeParser)
+
+    assert parser == expected_parser
+    assert result.exit_code == ExitCode.SUCCESS
+
+
 @pytest.mark.parametrize(
     "recipe_file, expected_recipe_file",
     [
@@ -59,7 +80,7 @@ def test_bump_recipe_cli(fs: FakeFilesystem, recipe_file: str, expected_recipe_f
         ("bump_recipe/build_num_-1.yaml", "simple-recipe.yaml"),
     ],
 )
-def test_bump_recipe_cli_build_num_true(fs: FakeFilesystem, recipe_file: str, expected_recipe_file: str) -> None:
+def test_bump_recipe_cli_build_num_flag_true(fs: FakeFilesystem, recipe_file: str, expected_recipe_file: str) -> None:
     """
     Test that the build number is successfully incremented by 1.
 
@@ -80,7 +101,7 @@ def test_bump_recipe_cli_build_num_true(fs: FakeFilesystem, recipe_file: str, ex
     assert result.exit_code == ExitCode.SUCCESS
 
 
-def test_bump_build_num_not_int(fs: FakeFilesystem) -> None:
+def test_bump_cli_build_num_not_int(fs: FakeFilesystem) -> None:
     """
     Test that the command fails gracefully case when the build number is not an integer,
     and we are trying to increment it.
@@ -97,7 +118,7 @@ def test_bump_build_num_not_int(fs: FakeFilesystem) -> None:
     assert result.exit_code == ExitCode.ILLEGAL_OPERATION
 
 
-def test_bump_build_num_key_not_found(fs: FakeFilesystem) -> None:
+def test_bump_cli_build_numb_key_not_found(fs: FakeFilesystem) -> None:
     """
     Test that the command fails gracefully when the build number key is missing and we try to increment it's value.
 
@@ -112,7 +133,7 @@ def test_bump_build_num_key_not_found(fs: FakeFilesystem) -> None:
     assert result.exit_code == ExitCode.ILLEGAL_OPERATION
 
 
-def test_bump_no_build_key_found(fs: FakeFilesystem) -> None:
+def test_bump_cli_no_build_key_found(fs: FakeFilesystem) -> None:
     """
     Test that the command fails gracefully when the build key is missing and we try to revert build number to zero.
 

--- a/tests/commands/test_bump_recipe.py
+++ b/tests/commands/test_bump_recipe.py
@@ -99,7 +99,7 @@ def test_bump_cli_build_number_not_int(fs: FakeFilesystem) -> None:
     assert result.exit_code == ExitCode.ILLEGAL_OPERATION
 
 
-def test_bump_cli_build_number_key_not_found(fs: FakeFilesystem) -> None:
+def test_bump_cli_increment_build_num_key_not_found(fs: FakeFilesystem) -> None:
     """
     Test that the command fails gracefully when the build number key is missing and we try to increment it's value.
 

--- a/tests/test_aux_files/bump_recipe/build_num_added.yaml
+++ b/tests/test_aux_files/bump_recipe/build_num_added.yaml
@@ -8,6 +8,7 @@ package:
 build:
   skip: true  # [py<37]
   is_true: true
+  number: 0
 
 # Comment above a top-level structure
 requirements:

--- a/tests/test_aux_files/bump_recipe/no_build_key.yaml
+++ b/tests/test_aux_files/bump_recipe/no_build_key.yaml
@@ -1,0 +1,48 @@
+{% set zz_non_alpha_first = 42 %}
+{% set name = "types-toml" %}
+{% set version = "0.10.8.6" %}
+
+package:
+  name: {{ name|lower }}  # [unix]
+
+# Comment above a top-level structure
+requirements:
+  empty_field1:
+  host:
+    - setuptools  # [unix]
+    - fakereq  # [unix] selector with comment
+  empty_field2:  # [unix and win] # selector with comment with comment symbol
+  run:
+    - python  # not a selector
+  empty_field3:
+
+about:
+  summary: This is a small recipe for testing
+  description: |
+    This is a PEP '561 type stub package for the toml package.
+    It can be used by type-checking tools like mypy, pyright,
+    pytype, PyCharm, etc. to check code that uses toml.
+  license: Apache-2.0 AND MIT
+
+multi_level:
+  list_1:
+    - foo
+    # Ensure a comment in a list is supported
+    - bar
+  list_2:
+    - cat
+    - bat
+    - mat
+  list_3:
+    - ls
+    - sl
+    - cowsay
+
+test_var_usage:
+  foo: {{ version }}
+  bar:
+    - baz
+    - {{ zz_non_alpha_first }}
+    - blah
+    - This {{ name }} is silly
+    - last


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

This PR adds the logic to set the `/build/number` back to 0 when `bump-recipe` command is run without any flags:

`crm bump-recipe <file.yaml>`

TODO:

- [x] Write tests

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->



<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/conda-recipe-manager/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda-incubator/conda-recipe-manager/blob/main/CONTRIBUTING.md -->
