### PR TITLE
Minor CI Improvements

### DIFF
--- a/.github/workflows/commit_checks.yaml
+++ b/.github/workflows/commit_checks.yaml
@@ -26,7 +26,7 @@ jobs:
       strategy:
         matrix:
           # NOTE: 3.11 is skipped as it is covered by the `pre-commit` job.
-          python-version: ["3.12", "3.13"]
+          python-version: ["3.12"]
       steps:
         - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         - uses: ./.github/actions/setup-env

--- a/.github/workflows/commit_checks.yaml
+++ b/.github/workflows/commit_checks.yaml
@@ -25,7 +25,8 @@ jobs:
       name: Test on ${{ matrix.python-version }}
       strategy:
         matrix:
-          python-version: ["3.11", "3.12"]
+          # NOTE: 3.11 is skipped as it is covered by the `pre-commit` job.
+          python-version: ["3.12", "3.13"]
       steps:
         - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         - uses: ./.github/actions/setup-env

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,3 +63,4 @@ repos:
     always_run: true
     pass_filenames: false
     entry: make test-cov
+    verbose: true

--- a/.pytest.ini
+++ b/.pytest.ini
@@ -3,7 +3,8 @@
 filterwarnings =
     # Turns warnings into errors so we are alerted in the CI pipeline
     error
-    # Further investigation needed, but this seems tied to the complex mockers used in the `fetcher` module.
+    # Further investigation needed, but this seems tied to the complex mockers used in the `fetcher` module. Tracked in
+    # Issue #237
     #   - https://docs.pytest.org/en/stable/reference/reference.html#pytest.PytestUnraisableExceptionWarning
     ignore::pytest.PytestUnraisableExceptionWarning
     # Root cause unclear, may be caused by `xdist` implementation for Linux. Tracked in  Issue #236

--- a/.pytest.ini
+++ b/.pytest.ini
@@ -1,8 +1,12 @@
 # This surpresses deprecation `pytest` warnings related to using `conda.*` packages.
 [pytest]
 filterwarnings =
+    # Turns warnings into errors so we are alerted in the CI pipeline
     error
+    # Further investigation needed, but this seems tied to the complex mockers used in the `fetcher` module.
+    #   https://docs.pytest.org/en/stable/reference/reference.html#pytest.PytestUnraisableExceptionWarning
     ignore::pytest.PytestUnraisableExceptionWarning
+    # Deprecation warnings from `conda`
     ignore::DeprecationWarning:boltons.*
     ignore::DeprecationWarning:xdist.*
 addopts = --ignore=tests/test_aux_files

--- a/.pytest.ini
+++ b/.pytest.ini
@@ -4,8 +4,12 @@ filterwarnings =
     # Turns warnings into errors so we are alerted in the CI pipeline
     error
     # Further investigation needed, but this seems tied to the complex mockers used in the `fetcher` module.
-    #   https://docs.pytest.org/en/stable/reference/reference.html#pytest.PytestUnraisableExceptionWarning
+    #   - https://docs.pytest.org/en/stable/reference/reference.html#pytest.PytestUnraisableExceptionWarning
     ignore::pytest.PytestUnraisableExceptionWarning
+    # Root cause unclear, may be caused by `xdist` implementation for Linux. Tracked in  Issue #236
+    #   - https://github.com/python/cpython/issues/100228
+    #   - https://github.com/python/cpython/pull/100229
+    ignore::DeprecationWarning:multiprocessing.popen_fork
     # Deprecation warnings from `conda`
     ignore::DeprecationWarning:boltons.*
     ignore::DeprecationWarning:xdist.*

--- a/.pytest.ini
+++ b/.pytest.ini
@@ -1,6 +1,8 @@
 # This surpresses deprecation `pytest` warnings related to using `conda.*` packages.
 [pytest]
 filterwarnings =
+    error
+    ignore::pytest.PytestUnraisableExceptionWarning
     ignore::DeprecationWarning:boltons.*
     ignore::DeprecationWarning:xdist.*
 addopts = --ignore=tests/test_aux_files

--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,9 @@ export PRINT_HELP_PYSCRIPT
 
 BROWSER := python -c "$$BROWSER_PYSCRIPT"
 
-clean: clean-test clean-build clean-env clean-docs ## remove all build, test, coverage, and Python artifacts
+clean: clean-test clean-build clean-env clean-docs ## Removes all build, test, coverage, and Python artifacts
 
-clean-build: ## remove build and Python artifacts
+clean-build: ## Removes build and Python artifacts
 	rm -fr build/
 	rm -fr dist/
 	rm -fr .eggs/
@@ -54,7 +54,7 @@ clean-build: ## remove build and Python artifacts
 clean-env:					## remove conda environment
 	conda remove -y -n $(CONDA_ENV_NAME) --all
 
-clean-test: ## remove test, coverage, and profiler artifacts
+clean-test: ## Removes test, coverage, and profiler artifacts
 	rm -fr .tox/
 	rm -f .coverage
 	rm -fr htmlcov/
@@ -72,33 +72,33 @@ clean-docs:	## Removes temporary and auto-generated static doc files
 help:
 	$(PYTHON3) -c "$$PRINT_HELP_PYSCRIPT" < $(MAKEFILE_LIST)
 
-dev: clean		## install the package's development version to a fresh environment
+dev: clean		## Installs the package's development version to a fresh environment
 	conda env create -f environment.yaml --name $(CONDA_ENV_NAME) --yes
 	conda run --name $(CONDA_ENV_NAME) pip install -e .
 	$(CONDA_ACTIVATE) $(CONDA_ENV_NAME) && pre-commit install
 
-pre-commit:     ## runs pre-commit against files. NOTE: older files are disabled in the pre-commit config.
+pre-commit:     ## Runs pre-commit against files.
 	pre-commit run --all-files
 
-test:			## runs test cases
+test:			## Runs test cases
 	$(PYTHON3) -m pytest -n auto --capture=no $(TEST_DIR)
 
-test-cov:		## checks test coverage requirements
+test-cov:		## Checks test coverage requirements
 	$(PYTHON3) -m pytest -n auto --cov-config=.coveragerc --cov=$(SRC_DIR) \
 		$(TEST_DIR) --cov-fail-under=80 --cov-report term-missing
 
-lint:			## runs the linter against the project
+lint:			## Runs the linter against the project
 	pylint --rcfile=.pylintrc $(SRC_DIR) $(TEST_DIR)
 
-format:			## runs the code auto-formatter
+format:			## Runs the code auto-formatter
 	isort --profile black --line-length=120 $(SRC_DIR) $(TEST_DIR) $(SCRIPTS_DIR)
 	black --line-length=120 $(SRC_DIR) $(TEST_DIR) $(SCRIPTS_DIR)
 
-format-docs:	## runs the docstring auto-formatter. NOTE: this requires manually installing `docconvert` with `pip`
+format-docs:	## Runs the docstring auto-formatter. NOTE: this requires manually installing `docconvert` with `pip`
 	docconvert --in-place --config .docconvert.json $(SRC_DIR)
 
-analyze:		## runs static analyzer on the project
+analyze:		## Runs static analyzer on the project
 	mypy --config-file=.mypy.ini --cache-dir=/dev/null $(SRC_DIR) $(TEST_DIR) $(SCRIPTS_DIR)
 
-docs: clean-docs	## generates static html documentation
+docs: clean-docs	## Generates static html documentation
 	$(MAKE) -C docs html


### PR DESCRIPTION
This PR makes a handful of minor CI improvements:
- Shows the `pytest` coverage logs in the pre-commit CI test to show current code coverage. This is done in such a way that any `pre-commit` command should show the test coverage report.
- Pytest warnings are now treated as errors so that we will know about warnings sooner (through CI failures)
- Minor documentation improvements in the `Makefile`
- Removes Python `3.11` from the test matrix, as `3.11` is used by the `pre-commit` job. In other words, we are now saving some redudant computation.

This also suppresses some new warnings I found while working on this issue. Issues #236 and #237 have been created as  a result.

I ended up NOT adding `python 3.13` tests to the test matrix as it does not appear to be ready yet.