### PR TITLE
143 Parse and Scan Dependencies from `pyprojecttoml`

### DIFF
--- a/conda_recipe_manager/scanner/dependency/base_dep_scanner.py
+++ b/conda_recipe_manager/scanner/dependency/base_dep_scanner.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from abc import ABCMeta, abstractmethod
 from typing import NamedTuple
 
-from conda_recipe_manager.parser.dependency import DependencySection
+from conda_recipe_manager.parser.dependency import DependencyData, DependencySection, dependency_data_from_str
 from conda_recipe_manager.types import MessageTable
 
 
@@ -15,11 +15,27 @@ class ProjectDependency(NamedTuple):
     """
     A dependency found by scanning a software project's files.
 
-    Not to be confused with `conda_recipe_manager.parser.dependency.Dependency`.
+    Not to be confused with the `conda_recipe_manager.parser.dependency.Dependency` type, which can be derived from
+    recipe file information.
     """
 
-    name: str
+    data: DependencyData
     type: DependencySection
+
+
+def new_project_dependency(s: str, t: DependencySection) -> ProjectDependency:
+    """
+    Convenience constructor for the `ProjectDependency` structure.
+
+    :param s: String containing the dependency name and optional version constraints.
+    :param t: Type of dependency. This also correlates with the section this dependency should be put in, in a `conda`
+        recipe file.
+    :returns: A newly constructed `ProjectDependency` instance.
+    """
+    return ProjectDependency(
+        data=dependency_data_from_str(s),
+        type=t,
+    )
 
 
 class BaseDependencyScanner(metaclass=ABCMeta):

--- a/conda_recipe_manager/scanner/dependency/base_dep_scanner.py
+++ b/conda_recipe_manager/scanner/dependency/base_dep_scanner.py
@@ -7,7 +7,8 @@ from __future__ import annotations
 from abc import ABCMeta, abstractmethod
 from typing import NamedTuple
 
-from conda_recipe_manager.types import DependencyType, MessageTable
+from conda_recipe_manager.parser.dependency import DependencySection
+from conda_recipe_manager.types import MessageTable
 
 
 class ProjectDependency(NamedTuple):
@@ -18,7 +19,7 @@ class ProjectDependency(NamedTuple):
     """
 
     name: str
-    type: DependencyType
+    type: DependencySection
 
 
 class BaseDependencyScanner(metaclass=ABCMeta):

--- a/conda_recipe_manager/scanner/dependency/py_dep_scanner.py
+++ b/conda_recipe_manager/scanner/dependency/py_dep_scanner.py
@@ -11,7 +11,11 @@ from pathlib import Path
 from typing import Final
 
 from conda_recipe_manager.parser.dependency import DependencySection
-from conda_recipe_manager.scanner.dependency.base_dep_scanner import BaseDependencyScanner, ProjectDependency
+from conda_recipe_manager.scanner.dependency.base_dep_scanner import (
+    BaseDependencyScanner,
+    ProjectDependency,
+    new_project_dependency,
+)
 from conda_recipe_manager.types import MessageCategory
 
 # Table that maps import names that do not match the package name for common packages. See this StackOverflow post for
@@ -123,7 +127,7 @@ class PythonDependencyScanner(BaseDependencyScanner):
                     else DependencySection.RUN
                 )
 
-                deps.add(ProjectDependency(package_name, dep_type))
+                deps.add(new_project_dependency(package_name, dep_type))
 
         return deps
 
@@ -150,7 +154,7 @@ class PythonDependencyScanner(BaseDependencyScanner):
         def _filter_test_duplicates(dep: ProjectDependency) -> bool:
             if (
                 dep.type == DependencySection.TESTS
-                and ProjectDependency(dep.name, DependencySection.RUN) in all_imports
+                and ProjectDependency(dep.data, DependencySection.RUN) in all_imports
             ):
                 return False
             return True
@@ -163,7 +167,7 @@ class PythonDependencyScanner(BaseDependencyScanner):
         # TODO filter unused imports
 
         # Python is inherently a HOST and RUN dependency for all Python projects.
-        all_imports.add(ProjectDependency("python", DependencySection.HOST))
-        all_imports.add(ProjectDependency("python", DependencySection.RUN))
+        all_imports.add(new_project_dependency("python", DependencySection.HOST))
+        all_imports.add(new_project_dependency("python", DependencySection.RUN))
 
         return all_imports

--- a/conda_recipe_manager/scanner/dependency/pyproject_dep_scanner.py
+++ b/conda_recipe_manager/scanner/dependency/pyproject_dep_scanner.py
@@ -1,0 +1,51 @@
+"""
+:Description: TODO
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+from typing import Final, cast
+
+from conda_recipe_manager.parser.dependency import DependencySection
+from conda_recipe_manager.scanner.dependency.base_dep_scanner import BaseDependencyScanner, ProjectDependency
+
+
+class PyProjectDependencyScanner(BaseDependencyScanner):
+    """
+    Dependency Scanner class capable of scanning `pyproject.toml` files.
+    """
+
+    def __init__(self, src_dir: Path | str):
+        """
+        Constructs a `PyProjectDependencyScanner`.
+
+        :param src_dir: Path to the Python source code to scan.
+        """
+        super().__init__()
+        self._src_dir: Final[Path] = Path(src_dir)
+
+    def scan(self) -> set[ProjectDependency]:
+        """
+        Actively scans a project for dependencies. Implementation is dependent on the type of scanner used.
+
+        :returns: A set of unique dependencies found by the scanner.
+        """
+        # TODO handle malformed `pyproject.toml` exceptions
+        # TODO perform schema check against `pyproject.toml`
+        with open(self._src_dir / "pyproject.toml", "rb") as f:
+            data = cast(dict[str, dict[str, list[str] | dict[str, list[str]]]], tomllib.load(f))
+
+        # TODO matchspec equivalency
+        deps: set[ProjectDependency] = set()
+        for dep_name in cast(list[str], data["project"]["dependencies"]):
+            deps.add(ProjectDependency(dep_name, DependencySection.RUN))
+
+        # Optional dependencies are stored in a dictionary, where the key is the "package extra" name and the value is
+        # a dependency list. For example: {'dev': ['pytest'], 'conda_build': ['conda-build']}
+        for dep_lst in cast(dict[str, list[str]], data["project"]["optional-dependencies"]).values():
+            for dep_name in dep_lst:
+                deps.add(ProjectDependency(dep_name, DependencySection.RUN_CONSTRAINTS))
+
+        return deps

--- a/conda_recipe_manager/scanner/dependency/pyproject_dep_scanner.py
+++ b/conda_recipe_manager/scanner/dependency/pyproject_dep_scanner.py
@@ -1,5 +1,5 @@
 """
-:Description: TODO
+:Description: Reads dependencies from a `pyproject.toml` file.
 """
 
 from __future__ import annotations
@@ -22,14 +22,17 @@ class PyProjectDependencyScanner(BaseDependencyScanner):
     Dependency Scanner class capable of scanning `pyproject.toml` files.
     """
 
-    def __init__(self, src_dir: Path | str):
+    def __init__(self, src_dir: Path | str, project_file_name: str = "pyproject.toml"):
         """
         Constructs a `PyProjectDependencyScanner`.
 
         :param src_dir: Path to the Python source code to scan.
+        :param project_file_name: (Optional) Allows for custom pyproject file names. Primarily used for testing,
+            defaults to standard `pyproject.toml` name.
         """
         super().__init__()
         self._src_dir: Final[Path] = Path(src_dir)
+        self._project_fn: Final[str] = project_file_name
 
     def scan(self) -> set[ProjectDependency]:
         """
@@ -38,7 +41,7 @@ class PyProjectDependencyScanner(BaseDependencyScanner):
         :returns: A set of unique dependencies found by the scanner, if any are found.
         """
         try:
-            with open(self._src_dir / "pyproject.toml", "rb") as f:
+            with open(self._src_dir / self._project_fn, "rb") as f:
                 data = cast(dict[str, dict[str, list[str] | dict[str, list[str]]]], tomllib.load(f))
         except (FileNotFoundError, tomllib.TOMLDecodeError) as e:
             if isinstance(e, FileNotFoundError):
@@ -50,7 +53,9 @@ class PyProjectDependencyScanner(BaseDependencyScanner):
         # NOTE: There is a `validate-pyproject` library hosted on `conda-forge`, but it is marked as "experimental" by
         # its maintainers. Given that and that we only read a small portion of the file, we only validate what we use.
         if "project" not in data:
-            self._msg_tbl.add_message(MessageCategory.ERROR, "`pyproject.toml` file is missing a `project` section.")
+            self._msg_tbl.add_message(
+                MessageCategory.ERROR, f"`{self._project_fn}` file is missing a `project` section."
+            )
             return set()
 
         # NOTE: The dependency constraint system used in `pyproject.toml` appears to be compatible with `conda`'s

--- a/conda_recipe_manager/scanner/dependency/pyproject_dep_scanner.py
+++ b/conda_recipe_manager/scanner/dependency/pyproject_dep_scanner.py
@@ -61,6 +61,8 @@ class PyProjectDependencyScanner(BaseDependencyScanner):
         # NOTE: The dependency constraint system used in `pyproject.toml` appears to be compatible with `conda`'s
         # `MatchSpec` object. For now, dependencies that can't be parsed with `MatchSpec` will store the raw string in
         # a `.name` field.
+        # TODO Future, consider handling Environment Markers:
+        #   https://packaging.python.org/en/latest/specifications/dependency-specifiers/#environment-markers
         deps: set[ProjectDependency] = set()
         for dep_name in cast(list[str], data["project"].get("dependencies", [])):
             deps.add(new_project_dependency(dep_name, DependencySection.RUN))

--- a/conda_recipe_manager/types.py
+++ b/conda_recipe_manager/types.py
@@ -60,17 +60,6 @@ class SentinelType:
             return _schema_type_singleton
 
 
-class DependencyType(StrEnum):
-    """
-    Enumerates the dependency categories found in Conda recipe files.
-    """
-
-    BUILD = auto()
-    HOST = auto()
-    RUN = auto()
-    TEST = auto()
-
-
 class MessageCategory(StrEnum):
     """
     Categories to classify messages into.

--- a/tests/scanner/dependency/test_py_dep_scanner.py
+++ b/tests/scanner/dependency/test_py_dep_scanner.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Final, cast
 
 import pytest
+from conda.models.match_spec import MatchSpec
 from pyfakefs.fake_filesystem import FakeFilesystem
 
 from conda_recipe_manager.parser.dependency import DependencySection
@@ -20,13 +21,13 @@ from tests.file_loading import get_test_path
         (
             "dummy_py_project_01",
             {
-                ProjectDependency("conda_recipe_manager", DependencySection.RUN),
-                ProjectDependency("matplotlib", DependencySection.RUN),  # Two imports on one line
-                ProjectDependency("networkx", DependencySection.RUN),  # Two imports on one line
-                ProjectDependency("python", DependencySection.HOST),
-                ProjectDependency("python", DependencySection.RUN),
-                ProjectDependency("pyyaml", DependencySection.TESTS),
-                ProjectDependency("requests", DependencySection.RUN),  # Found in source and test code.
+                ProjectDependency(MatchSpec("conda_recipe_manager"), DependencySection.RUN),
+                ProjectDependency(MatchSpec("matplotlib"), DependencySection.RUN),  # Two imports on one line
+                ProjectDependency(MatchSpec("networkx"), DependencySection.RUN),  # Two imports on one line
+                ProjectDependency(MatchSpec("python"), DependencySection.HOST),
+                ProjectDependency(MatchSpec("python"), DependencySection.RUN),
+                ProjectDependency(MatchSpec("pyyaml"), DependencySection.TESTS),
+                ProjectDependency(MatchSpec("requests"), DependencySection.RUN),  # Found in source and test code.
             },
         ),
     ],

--- a/tests/scanner/dependency/test_py_dep_scanner.py
+++ b/tests/scanner/dependency/test_py_dep_scanner.py
@@ -8,9 +8,9 @@ from typing import Final, cast
 import pytest
 from pyfakefs.fake_filesystem import FakeFilesystem
 
+from conda_recipe_manager.parser.dependency import DependencySection
 from conda_recipe_manager.scanner.dependency.base_dep_scanner import ProjectDependency
 from conda_recipe_manager.scanner.dependency.py_dep_scanner import PythonDependencyScanner
-from conda_recipe_manager.types import DependencyType
 from tests.file_loading import get_test_path
 
 
@@ -20,13 +20,13 @@ from tests.file_loading import get_test_path
         (
             "dummy_py_project_01",
             {
-                ProjectDependency("conda_recipe_manager", DependencyType.RUN),
-                ProjectDependency("matplotlib", DependencyType.RUN),  # Two imports on one line
-                ProjectDependency("networkx", DependencyType.RUN),  # Two imports on one line
-                ProjectDependency("python", DependencyType.HOST),
-                ProjectDependency("python", DependencyType.RUN),
-                ProjectDependency("pyyaml", DependencyType.TEST),
-                ProjectDependency("requests", DependencyType.RUN),  # Found in source and test code.
+                ProjectDependency("conda_recipe_manager", DependencySection.RUN),
+                ProjectDependency("matplotlib", DependencySection.RUN),  # Two imports on one line
+                ProjectDependency("networkx", DependencySection.RUN),  # Two imports on one line
+                ProjectDependency("python", DependencySection.HOST),
+                ProjectDependency("python", DependencySection.RUN),
+                ProjectDependency("pyyaml", DependencySection.TESTS),
+                ProjectDependency("requests", DependencySection.RUN),  # Found in source and test code.
             },
         ),
     ],

--- a/tests/scanner/dependency/test_pyproject_dep_scanner.py
+++ b/tests/scanner/dependency/test_pyproject_dep_scanner.py
@@ -33,6 +33,23 @@ from tests.file_loading import get_test_path
             },
         ),
         (
+            "crm_mock_pyproject_version_constraints.toml",
+            {
+                ProjectDependency(MatchSpec("click >= 1.2"), DependencySection.RUN),
+                ProjectDependency(MatchSpec("jinja2"), DependencySection.RUN),
+                ProjectDependency(MatchSpec("pyyaml"), DependencySection.RUN),
+                ProjectDependency(MatchSpec("jsonschema"), DependencySection.RUN),
+                ProjectDependency(MatchSpec("requests >= 2.8.1, == 2.8.*"), DependencySection.RUN),
+                ProjectDependency(MatchSpec("gitpython"), DependencySection.RUN),
+                ProjectDependency(MatchSpec("networkx"), DependencySection.RUN),
+                ProjectDependency(MatchSpec("matplotlib"), DependencySection.RUN),
+                ProjectDependency(MatchSpec("pygraphviz"), DependencySection.RUN),
+                # Optional dependencies
+                ProjectDependency(MatchSpec("pytest ~= 8.1"), DependencySection.RUN_CONSTRAINTS),
+                ProjectDependency(MatchSpec("conda-build"), DependencySection.RUN_CONSTRAINTS),
+            },
+        ),
+        (
             "crm_mock_pyproject_only_deps.toml",
             {
                 ProjectDependency(MatchSpec("click"), DependencySection.RUN),

--- a/tests/scanner/dependency/test_pyproject_dep_scanner.py
+++ b/tests/scanner/dependency/test_pyproject_dep_scanner.py
@@ -32,6 +32,27 @@ from tests.file_loading import get_test_path
                 ProjectDependency(MatchSpec("conda-build"), DependencySection.RUN_CONSTRAINTS),
             },
         ),
+        (
+            "crm_mock_pyproject_only_deps.toml",
+            {
+                ProjectDependency(MatchSpec("click"), DependencySection.RUN),
+                ProjectDependency(MatchSpec("jinja2"), DependencySection.RUN),
+                ProjectDependency(MatchSpec("pyyaml"), DependencySection.RUN),
+                ProjectDependency(MatchSpec("jsonschema"), DependencySection.RUN),
+                ProjectDependency(MatchSpec("requests"), DependencySection.RUN),
+                ProjectDependency(MatchSpec("gitpython"), DependencySection.RUN),
+                ProjectDependency(MatchSpec("networkx"), DependencySection.RUN),
+                ProjectDependency(MatchSpec("matplotlib"), DependencySection.RUN),
+                ProjectDependency(MatchSpec("pygraphviz"), DependencySection.RUN),
+            },
+        ),
+        (
+            "crm_mock_pyproject_only_optional.toml",
+            {
+                ProjectDependency(MatchSpec("pytest"), DependencySection.RUN_CONSTRAINTS),
+                ProjectDependency(MatchSpec("conda-build"), DependencySection.RUN_CONSTRAINTS),
+            },
+        ),
     ],
 )
 def test_scan(project_fn: str, expected: set[ProjectDependency]) -> None:

--- a/tests/scanner/dependency/test_pyproject_dep_scanner.py
+++ b/tests/scanner/dependency/test_pyproject_dep_scanner.py
@@ -1,0 +1,78 @@
+"""
+:Description: Provides unit tests for the `PyProjectDependencyScanner` class.
+"""
+
+import pytest
+from conda.models.match_spec import MatchSpec
+
+from conda_recipe_manager.parser.dependency import DependencySection
+from conda_recipe_manager.scanner.dependency.base_dep_scanner import ProjectDependency
+from conda_recipe_manager.scanner.dependency.pyproject_dep_scanner import PyProjectDependencyScanner
+from conda_recipe_manager.types import MessageCategory
+from tests.file_loading import get_test_path
+
+
+@pytest.mark.parametrize(
+    "project_fn,expected",
+    [
+        (
+            "crm_mock_pyproject.toml",
+            {
+                ProjectDependency(MatchSpec("click"), DependencySection.RUN),
+                ProjectDependency(MatchSpec("jinja2"), DependencySection.RUN),
+                ProjectDependency(MatchSpec("pyyaml"), DependencySection.RUN),
+                ProjectDependency(MatchSpec("jsonschema"), DependencySection.RUN),
+                ProjectDependency(MatchSpec("requests"), DependencySection.RUN),
+                ProjectDependency(MatchSpec("gitpython"), DependencySection.RUN),
+                ProjectDependency(MatchSpec("networkx"), DependencySection.RUN),
+                ProjectDependency(MatchSpec("matplotlib"), DependencySection.RUN),
+                ProjectDependency(MatchSpec("pygraphviz"), DependencySection.RUN),
+                # Optional dependencies
+                ProjectDependency(MatchSpec("pytest"), DependencySection.RUN_CONSTRAINTS),
+                ProjectDependency(MatchSpec("conda-build"), DependencySection.RUN_CONSTRAINTS),
+            },
+        ),
+    ],
+)
+def test_scan(project_fn: str, expected: set[ProjectDependency]) -> None:
+    """
+    Tests scanning for Python dependencies with a mocked-out Python project.
+
+    :param project_fn: Name of the dummy `pyproject.toml` file to use.
+    :param expected: Expected value
+    """
+    scanner = PyProjectDependencyScanner(get_test_path() / "pyproject_toml", project_fn)
+    assert scanner.scan() == expected
+
+
+def test_scan_missing_pyproject() -> None:
+    """
+    Tests that the scanner fails gracefully if a `pyproject.toml` file could not be found
+    """
+    scanner = PyProjectDependencyScanner(get_test_path() / "pyproject_toml", "the_limit_dne.toml")
+    assert scanner.scan() == set()
+    assert scanner.get_message_table().get_messages(MessageCategory.EXCEPTION) == [
+        "`the_limit_dne.toml` file not found."
+    ]
+
+
+def test_scan_corrupt_pyproject() -> None:
+    """
+    Tests that the scanner fails gracefully if the `pyproject.toml` file is corrupt.
+    """
+    scanner = PyProjectDependencyScanner(get_test_path() / "pyproject_toml", "corrupt_pyproject.toml")
+    assert scanner.scan() == set()
+    assert scanner.get_message_table().get_messages(MessageCategory.EXCEPTION) == [
+        "Could not parse `corrupt_pyproject.toml` file."
+    ]
+
+
+def test_scan_missing_project_pyproject() -> None:
+    """
+    Tests that the scanner fails gracefully if the `pyproject.toml` file is missing a `project` section.
+    """
+    scanner = PyProjectDependencyScanner(get_test_path() / "pyproject_toml", "no_project_pyproject.toml")
+    assert scanner.scan() == set()
+    assert scanner.get_message_table().get_messages(MessageCategory.ERROR) == [
+        "`no_project_pyproject.toml` file is missing a `project` section."
+    ]

--- a/tests/test_aux_files/pyproject_toml/corrupt_pyproject.toml
+++ b/tests/test_aux_files/pyproject_toml/corrupt_pyproject.toml
@@ -1,0 +1,5 @@
+[project
+dependencies = [
+  "click",
+  "jsonschema"
+]

--- a/tests/test_aux_files/pyproject_toml/crm_mock_pyproject.toml
+++ b/tests/test_aux_files/pyproject_toml/crm_mock_pyproject.toml
@@ -1,0 +1,63 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+include-package-data = true
+
+[tool.setuptools.packages.find]
+namespaces = false
+exclude = ["tests"]
+
+[tool.setuptools.package-data]
+"conda_recipe_manager" = ["py.typed", "licenses/*.json"]
+
+[project]
+name = "conda_recipe_manager"
+version = "0.3.4"
+authors = [
+  { name="Anaconda, Inc.", email="distribution_team@anaconda.com" },
+]
+description = "Fast and rough renderer of conda recipes."
+readme = "README.md"
+license = {file = "LICENSE"}
+requires-python = ">=3.11"
+keywords = ["renderer", "conda recipe"]
+classifiers = [
+    "Development Status :: 2 - Pre-Alpha",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: BSD License",
+    "Natural Language :: English",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Topic :: Software Development :: Quality Assurance",
+    "Topic :: Utilities",
+]
+dependencies = [
+  "click",
+  "jinja2",
+  "pyyaml",
+  "jsonschema",
+  "requests",
+  "gitpython",
+  "networkx",
+  "matplotlib",
+  "pygraphviz",
+]
+
+[project.optional-dependencies]
+dev = ["pytest"]
+conda_build = ["conda-build"]
+
+[project.scripts]
+conda-recipe-manager = "conda_recipe_manager.commands.conda_recipe_manager:conda_recipe_manager"
+crm = "conda_recipe_manager.commands.conda_recipe_manager:conda_recipe_manager"
+
+[project.urls]
+"Homepage" = "https://github.com/anaconda/conda-recipe-manager"
+"Bug Tracker" = "https://github.com/anaconda/conda-recipe-manager/issues"
+"Repository" = "https://github.com/anaconda/conda-recipe-manager"
+"Documentation" = "https://github.com/anaconda/conda-recipe-manager/blob/main/README.md"

--- a/tests/test_aux_files/pyproject_toml/crm_mock_pyproject_only_deps.toml
+++ b/tests/test_aux_files/pyproject_toml/crm_mock_pyproject_only_deps.toml
@@ -1,0 +1,59 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+include-package-data = true
+
+[tool.setuptools.packages.find]
+namespaces = false
+exclude = ["tests"]
+
+[tool.setuptools.package-data]
+"conda_recipe_manager" = ["py.typed", "licenses/*.json"]
+
+[project]
+name = "conda_recipe_manager"
+version = "0.3.4"
+authors = [
+  { name="Anaconda, Inc.", email="distribution_team@anaconda.com" },
+]
+description = "Fast and rough renderer of conda recipes."
+readme = "README.md"
+license = {file = "LICENSE"}
+requires-python = ">=3.11"
+keywords = ["renderer", "conda recipe"]
+classifiers = [
+    "Development Status :: 2 - Pre-Alpha",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: BSD License",
+    "Natural Language :: English",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Topic :: Software Development :: Quality Assurance",
+    "Topic :: Utilities",
+]
+dependencies = [
+  "click",
+  "jinja2",
+  "pyyaml",
+  "jsonschema",
+  "requests",
+  "gitpython",
+  "networkx",
+  "matplotlib",
+  "pygraphviz",
+]
+
+[project.scripts]
+conda-recipe-manager = "conda_recipe_manager.commands.conda_recipe_manager:conda_recipe_manager"
+crm = "conda_recipe_manager.commands.conda_recipe_manager:conda_recipe_manager"
+
+[project.urls]
+"Homepage" = "https://github.com/anaconda/conda-recipe-manager"
+"Bug Tracker" = "https://github.com/anaconda/conda-recipe-manager/issues"
+"Repository" = "https://github.com/anaconda/conda-recipe-manager"
+"Documentation" = "https://github.com/anaconda/conda-recipe-manager/blob/main/README.md"

--- a/tests/test_aux_files/pyproject_toml/crm_mock_pyproject_only_optional.toml
+++ b/tests/test_aux_files/pyproject_toml/crm_mock_pyproject_only_optional.toml
@@ -1,0 +1,52 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+include-package-data = true
+
+[tool.setuptools.packages.find]
+namespaces = false
+exclude = ["tests"]
+
+[tool.setuptools.package-data]
+"conda_recipe_manager" = ["py.typed", "licenses/*.json"]
+
+[project]
+name = "conda_recipe_manager"
+version = "0.3.4"
+authors = [
+  { name="Anaconda, Inc.", email="distribution_team@anaconda.com" },
+]
+description = "Fast and rough renderer of conda recipes."
+readme = "README.md"
+license = {file = "LICENSE"}
+requires-python = ">=3.11"
+keywords = ["renderer", "conda recipe"]
+classifiers = [
+    "Development Status :: 2 - Pre-Alpha",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: BSD License",
+    "Natural Language :: English",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Topic :: Software Development :: Quality Assurance",
+    "Topic :: Utilities",
+]
+
+[project.optional-dependencies]
+dev = ["pytest"]
+conda_build = ["conda-build"]
+
+[project.scripts]
+conda-recipe-manager = "conda_recipe_manager.commands.conda_recipe_manager:conda_recipe_manager"
+crm = "conda_recipe_manager.commands.conda_recipe_manager:conda_recipe_manager"
+
+[project.urls]
+"Homepage" = "https://github.com/anaconda/conda-recipe-manager"
+"Bug Tracker" = "https://github.com/anaconda/conda-recipe-manager/issues"
+"Repository" = "https://github.com/anaconda/conda-recipe-manager"
+"Documentation" = "https://github.com/anaconda/conda-recipe-manager/blob/main/README.md"

--- a/tests/test_aux_files/pyproject_toml/crm_mock_pyproject_version_constraints.toml
+++ b/tests/test_aux_files/pyproject_toml/crm_mock_pyproject_version_constraints.toml
@@ -1,0 +1,64 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+include-package-data = true
+
+[tool.setuptools.packages.find]
+namespaces = false
+exclude = ["tests"]
+
+[tool.setuptools.package-data]
+"conda_recipe_manager" = ["py.typed", "licenses/*.json"]
+
+[project]
+name = "conda_recipe_manager"
+version = "0.3.4"
+authors = [
+  { name="Anaconda, Inc.", email="distribution_team@anaconda.com" },
+]
+description = "Fast and rough renderer of conda recipes."
+readme = "README.md"
+license = {file = "LICENSE"}
+requires-python = ">=3.11"
+keywords = ["renderer", "conda recipe"]
+classifiers = [
+    "Development Status :: 2 - Pre-Alpha",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: BSD License",
+    "Natural Language :: English",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Topic :: Software Development :: Quality Assurance",
+    "Topic :: Utilities",
+]
+
+dependencies = [
+  "click>=1.2",
+  "jinja2",
+  "pyyaml",
+  "jsonschema",
+  "requests >= 2.8.1, == 2.8.*",
+  "gitpython",
+  "networkx",
+  "matplotlib",
+  "pygraphviz",
+]
+
+[project.optional-dependencies]
+dev = ["pytest ~=8.1"]
+conda_build = ["conda-build"]
+
+[project.scripts]
+conda-recipe-manager = "conda_recipe_manager.commands.conda_recipe_manager:conda_recipe_manager"
+crm = "conda_recipe_manager.commands.conda_recipe_manager:conda_recipe_manager"
+
+[project.urls]
+"Homepage" = "https://github.com/anaconda/conda-recipe-manager"
+"Bug Tracker" = "https://github.com/anaconda/conda-recipe-manager/issues"
+"Repository" = "https://github.com/anaconda/conda-recipe-manager"
+"Documentation" = "https://github.com/anaconda/conda-recipe-manager/blob/main/README.md"

--- a/tests/test_aux_files/pyproject_toml/no_project_pyproject.toml
+++ b/tests/test_aux_files/pyproject_toml/no_project_pyproject.toml
@@ -1,0 +1,2 @@
+[tool.setuptools]
+include-package-data = true


### PR DESCRIPTION
Introduces the initial version of the `PyProjectDependencyScanner` class. Dependencies found in the `pyproject.toml` are labeled as `RUN` dependencies, while optionals are `RUN_CONSTRAINED`. As far as I currently understand it, this is the best mapping between the `pyproject.toml` standard and our `conda` recipe file format.

Also includes:
- New unit tests
- A minor refactor that removes some duplicated data structures and types found in the `parser` module