### PR TITLE
169 Calculate and Change the SHA-256 hash for http/https Artifacts

### DIFF
--- a/.pytest.ini
+++ b/.pytest.ini
@@ -14,4 +14,4 @@ filterwarnings =
     # Deprecation warnings from `conda`
     ignore::DeprecationWarning:boltons.*
     ignore::DeprecationWarning:xdist.*
-addopts = --ignore=tests/test_aux_files
+addopts = --ignore=tests/test_aux_files --disable-socket

--- a/conda_recipe_manager/commands/bump_recipe.py
+++ b/conda_recipe_manager/commands/bump_recipe.py
@@ -85,6 +85,7 @@ def _update_sha256(recipe_parser: RecipeParser) -> None:
     """
     fetcher_lst = af_from_recipe(recipe_parser, True)
     if not fetcher_lst:
+        # TODO log
         return
 
     # TODO handle case where SHA is stored in one or more variables (see cctools-ld64.yaml)

--- a/conda_recipe_manager/commands/bump_recipe.py
+++ b/conda_recipe_manager/commands/bump_recipe.py
@@ -78,6 +78,8 @@ def _update_sha256(recipe_parser: RecipeParser) -> None:
     only required for build artifacts that are hosted as compressed software archives. If this field must be updated,
     a lengthy network request may be required to calculate the new hash.
 
+    NOTE: For this to make any meaningful changes, the `version` field will need to be updated first.
+
     :param recipe_parser: Recipe file to update.
     """
     fetcher_lst = af_from_recipe(recipe_parser, True)
@@ -136,7 +138,8 @@ def bump_recipe(recipe_file_path: str, build_num: bool) -> None:
 
     # Attempt to update fields
     _update_build_num(recipe_parser, build_num)
-    _update_sha256(recipe_parser)
+    if not build_num:
+        _update_sha256(recipe_parser)
 
     Path(recipe_file_path).write_text(recipe_parser.render(), encoding="utf-8")
     sys.exit(ExitCode.SUCCESS)

--- a/conda_recipe_manager/commands/bump_recipe.py
+++ b/conda_recipe_manager/commands/bump_recipe.py
@@ -15,6 +15,7 @@ from conda_recipe_manager.commands.utils.types import ExitCode
 from conda_recipe_manager.fetcher.artifact_fetcher import from_recipe as af_from_recipe
 from conda_recipe_manager.fetcher.http_artifact_fetcher import HttpArtifactFetcher
 from conda_recipe_manager.parser.recipe_parser import RecipeParser
+from conda_recipe_manager.parser.recipe_reader import RecipeReader
 from conda_recipe_manager.types import JsonPatchType
 
 
@@ -101,10 +102,11 @@ def _update_sha256(recipe_parser: RecipeParser) -> None:
         # TODO attempt fetch in the background, especially if multiple fetch() calls are required.
         fetcher.fetch()
         sha = fetcher.get_archive_sha256()
+        sha_path = RecipeReader.append_to_path(src_path, "/sha256")
 
         # Guard against the unlikely scenario that the `sha256` field is missing.
-        patch_op = "replace" if recipe_parser.contains_value(src_path) else "add"
-        _exit_on_failed_patch(recipe_parser, {"op": patch_op, "path": src_path, "value": sha})
+        patch_op = "replace" if recipe_parser.contains_value(sha_path) else "add"
+        _exit_on_failed_patch(recipe_parser, {"op": patch_op, "path": sha_path, "value": sha})
 
 
 # TODO Improve. In order for `click` to play nice with `pyfakefs`, we set `path_type=str` and delay converting to a

--- a/conda_recipe_manager/commands/bump_recipe.py
+++ b/conda_recipe_manager/commands/bump_recipe.py
@@ -67,6 +67,7 @@ def _update_sha256(recipe_parser: RecipeParser) -> None:
         return
 
     # TODO handle case where SHA is stored in one or more variables (see cctools-ld64.yaml)
+    # TODO handle case where SHA is a variable
 
     # TODO Future: Figure out
     # NOTE: Each source _might_ have a different SHA-256 hash. This is the case for the `cctools-ld64` feedstock. That
@@ -80,8 +81,10 @@ def _update_sha256(recipe_parser: RecipeParser) -> None:
         # TODO attempt fetch in the background, especially if multiple fetch() calls are required.
         fetcher.fetch()
         sha = fetcher.get_archive_sha256()
-        # TODO make this an `add` op if the path is missing
-        recipe_parser.patch({"op": "replace", "path": src_path, "value": sha})
+
+        # Guard against the unlikely scenario that the `sha256` field is missing.
+        patch_op = "replace" if recipe_parser.contains_value(src_path) else "add"
+        recipe_parser.patch({"op": patch_op, "path": src_path, "value": sha})
 
 
 # TODO Improve. In order for `click` to play nice with `pyfakefs`, we set `path_type=str` and delay converting to a

--- a/conda_recipe_manager/commands/utils/types.py
+++ b/conda_recipe_manager/commands/utils/types.py
@@ -35,6 +35,9 @@ class ExitCode(IntEnum):
     PRE_PROCESS_EXCEPTION = 105
     ILLEGAL_OPERATION = 106
 
+    # bump-recipe
+    PATCH_ERROR = 107
+
     ## rattler-bulk-build ##
     # NOTE: There may be overlap with rattler-build
 

--- a/conda_recipe_manager/fetcher/artifact_fetcher.py
+++ b/conda_recipe_manager/fetcher/artifact_fetcher.py
@@ -69,8 +69,10 @@ def from_recipe(recipe: RecipeReader, ignore_unsupported: bool = False) -> dict[
     # TODO Handle selector evaluation/determine how common it is to have a selector in `/source`
 
     # Normalize to a list to handle both single and multi-source cases.
+    is_src_lst = True
     if not isinstance(parsed_sources, list):
         parsed_sources = [parsed_sources]
+        is_src_lst = False
 
     recipe_name = recipe.get_recipe_name()
     if recipe_name is None:
@@ -85,7 +87,8 @@ def from_recipe(recipe: RecipeReader, ignore_unsupported: bool = False) -> dict[
 
         src_name = recipe_name if len(parsed_sources) == 1 else f"{recipe_name}_{i}"
 
-        src_path = f"/source/{i}"
+        # If the source section is not a list, it contains one "flag" source object.
+        src_path = f"/source/{i}" if is_src_lst else "/source"
         if url is not None:
             sources[src_path] = HttpArtifactFetcher(src_name, url)
         elif git_url is not None:
@@ -97,6 +100,6 @@ def from_recipe(recipe: RecipeReader, ignore_unsupported: bool = False) -> dict[
                 rev=optional_str(parsed_source.get(_render_git_key(recipe, "git_rev"))),
             )
         elif not ignore_unsupported:
-            raise FetchUnsupportedError(f"{recipe_name} contains an unsupported source object at `/source/{i}`.")
+            raise FetchUnsupportedError(f"{recipe_name} contains an unsupported source object at `{src_path}`.")
 
     return sources

--- a/environment.yaml
+++ b/environment.yaml
@@ -10,6 +10,7 @@ dependencies:
   - python >=3.11
   - pytest
   - pytest-cov
+  - conda-forge::pytest-socket
   - pytest-xdist
   - pyfakefs
   # Match version with .pre-commit-config.yaml to ensure consistent rules with `make lint`.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,6 +46,7 @@ test:
     - pip
     - pytest
     - pytest-xdist
+    - pytest-socket
     - pyfakefs
   commands:
     - pip check

--- a/tests/commands/test_bump_recipe.py
+++ b/tests/commands/test_bump_recipe.py
@@ -2,7 +2,8 @@
 :Description: Tests the `bump-recipe` CLI
 """
 
-from typing import Final
+from typing import Final, cast
+from unittest.mock import patch
 
 import pytest
 from click.testing import CliRunner
@@ -10,9 +11,62 @@ from pyfakefs.fake_filesystem import FakeFilesystem
 
 from conda_recipe_manager.commands import bump_recipe
 from conda_recipe_manager.commands.utils.types import ExitCode
+from conda_recipe_manager.fetcher.http_artifact_fetcher import HttpArtifactFetcher
 from conda_recipe_manager.parser.recipe_parser import RecipeParser
 from tests.file_loading import get_test_path, load_recipe
+from tests.http_mocking import MockHttpStreamResponse
 from tests.smoke_testing import assert_cli_usage
+
+
+class MockUrl:
+    """
+    Namespace for mocked URLs
+    """
+
+    # URL endpoint(s) used by the `types-toml.yaml` file
+    TYPES_TOML_V0_10_8_20240310_URL: Final[str] = (
+        "https://pypi.io/packages/source/t/types-toml/types-toml-0.10.8.20240310.tar.gz"
+    )
+
+    # Failed URL
+    PYPI_HTTP_500: Final[str] = "https://pypi.io/error_500.html"
+
+
+@pytest.fixture(name="http_fetcher_types_toml")
+def fixture_http_fetcher_types_toml() -> HttpArtifactFetcher:
+    """
+    `HttpArtifactFetcher` test fixture for the `types-toml` project.
+    """
+    return HttpArtifactFetcher("types-toml", MockUrl.TYPES_TOML_V0_10_8_20240310_URL)
+
+
+@pytest.fixture(name="http_pypi_failure")
+def fixture_http_pypi_failure() -> HttpArtifactFetcher:
+    """
+    Single-instance `HttpArtifactFetcher` test fixture. This can be used for error cases that don't need multiple tests
+    to be run or need to simulate a failed HTTP request.
+    """
+    return HttpArtifactFetcher("pypi_failure", MockUrl.PYPI_HTTP_500)
+
+
+def mock_requests_get(*args: tuple[str], **_: dict[str, str | int]) -> MockHttpStreamResponse:
+    """
+    Mocking function for HTTP requests made in this test file.
+
+    NOTE: The artifacts provided are not the real build artifacts.
+
+    :param args: Arguments passed to the `requests.get()`
+    :param _: Name-specified arguments passed to `requests.get()` (Unused)
+    """
+    endpoint = cast(str, args[0])
+    match endpoint:
+        case MockUrl.TYPES_TOML_V0_10_8_20240310_URL:
+            return MockHttpStreamResponse(200, "archive_files/dummy_project_01.tar.gz")
+        case MockUrl.PYPI_HTTP_500:
+            return MockHttpStreamResponse(500, "archive_files/dummy_project_01.tar.gz")
+        case _:
+            # TODO fix: pyfakefs does include `/dev/null` by default, but this actually points to `<temp_dir>/dev/null`
+            return MockHttpStreamResponse(404, "/dev/null")
 
 
 def test_usage() -> None:
@@ -23,10 +77,13 @@ def test_usage() -> None:
 
 
 @pytest.mark.parametrize(
-    "recipe_file, increment_build_num, expected_recipe_file",
+    "recipe_file,increment_build_num,expected_recipe_file",
     [
-        ("simple-recipe.yaml", True, "bump_recipe/build_num_1.yaml"),
-        ("simple-recipe.yaml", False, "simple-recipe.yaml"),
+        ("types-toml.yaml", True, "bump_recipe/types-toml_build_num_1.yaml"),
+        # TODO: Re-enable test when version bumping is supported.
+        # ("types-toml.yaml", False, "bump_recipe/types-toml_version_bump.yaml"),
+        # NOTE: These have no source section, therefore all SHA-256 update attempts (and associated network requests)
+        # should be skipped.
         ("bump_recipe/build_num_1.yaml", True, "bump_recipe/build_num_2.yaml"),
         ("bump_recipe/build_num_1.yaml", False, "simple-recipe.yaml"),
         ("bump_recipe/build_num_42.yaml", True, "bump_recipe/build_num_43.yaml"),
@@ -36,12 +93,16 @@ def test_usage() -> None:
     ],
 )
 def test_bump_recipe_cli(
-    fs: FakeFilesystem, recipe_file: str, increment_build_num: bool, expected_recipe_file: str
+    fs: FakeFilesystem,
+    recipe_file: str,
+    increment_build_num: bool,
+    expected_recipe_file: str,
 ) -> None:
     """
     Test that the recipe file is successfully updated/bumped.
 
     :param fs: `pyfakefs` Fixture used to replace the file system
+    :param request: Pytest fixture request object.
     """
     runner = CliRunner()
     fs.add_real_directory(get_test_path(), read_only=False)
@@ -52,7 +113,9 @@ def test_bump_recipe_cli(
     cli_args: Final[list[str]] = (
         ["--build-num", str(recipe_file_path)] if increment_build_num else [str(recipe_file_path)]
     )
-    result = runner.invoke(bump_recipe.bump_recipe, cli_args)
+
+    with patch("requests.get", new=mock_requests_get):
+        result = runner.invoke(bump_recipe.bump_recipe, cli_args)
 
     parser = load_recipe(recipe_file_path, RecipeParser)
     expected_parser = load_recipe(expected_recipe_file_path, RecipeParser)

--- a/tests/fetcher/test_artifact_fetcher.py
+++ b/tests/fetcher/test_artifact_fetcher.py
@@ -24,10 +24,28 @@ from tests.file_loading import get_test_path, load_recipe
         ("types-toml.yaml", {"/source/0": HttpArtifactFetcher}),
         ("multi-output.yaml", {}),
         ("git-src.yaml", {"/source/0": GitArtifactFetcher}),
+        (
+            "cctools-ld64.yaml",
+            {
+                "/source/0": HttpArtifactFetcher,
+                "/source/1": HttpArtifactFetcher,
+                "/source/2": HttpArtifactFetcher,
+                "/source/3": HttpArtifactFetcher,
+            },
+        ),
         ## V1 Format ##
         ("v1_format/v1_types-toml.yaml", {"/source/0": HttpArtifactFetcher}),
         ("v1_format/v1_multi-output.yaml", {}),
         ("v1_format/v1_git-src.yaml", {"/source/0": GitArtifactFetcher}),
+        (
+            "v1_format/v1_cctools-ld64.yaml",
+            {
+                "/source/0": HttpArtifactFetcher,
+                "/source/1": HttpArtifactFetcher,
+                "/source/2": HttpArtifactFetcher,
+                "/source/3": HttpArtifactFetcher,
+            },
+        ),
     ],
 )
 def test_from_recipe_ignore_unsupported(

--- a/tests/fetcher/test_artifact_fetcher.py
+++ b/tests/fetcher/test_artifact_fetcher.py
@@ -1,5 +1,5 @@
 """
-:Description: TODO
+:Description: Unit test file for Artifact Fetcher utilities and factory constructors.
 """
 
 from __future__ import annotations
@@ -21,9 +21,9 @@ from tests.file_loading import get_test_path, load_recipe
     "file,expected",
     [
         ## V0 Format ##
-        ("types-toml.yaml", {"/source/0": HttpArtifactFetcher}),
+        ("types-toml.yaml", {"/source": HttpArtifactFetcher}),
         ("multi-output.yaml", {}),
-        ("git-src.yaml", {"/source/0": GitArtifactFetcher}),
+        ("git-src.yaml", {"/source": GitArtifactFetcher}),
         (
             "cctools-ld64.yaml",
             {
@@ -34,9 +34,9 @@ from tests.file_loading import get_test_path, load_recipe
             },
         ),
         ## V1 Format ##
-        ("v1_format/v1_types-toml.yaml", {"/source/0": HttpArtifactFetcher}),
+        ("v1_format/v1_types-toml.yaml", {"/source": HttpArtifactFetcher}),
         ("v1_format/v1_multi-output.yaml", {}),
-        ("v1_format/v1_git-src.yaml", {"/source/0": GitArtifactFetcher}),
+        ("v1_format/v1_git-src.yaml", {"/source": GitArtifactFetcher}),
         (
             "v1_format/v1_cctools-ld64.yaml",
             {

--- a/tests/fetcher/test_artifact_fetcher.py
+++ b/tests/fetcher/test_artifact_fetcher.py
@@ -21,17 +21,17 @@ from tests.file_loading import get_test_path, load_recipe
     "file,expected",
     [
         ## V0 Format ##
-        ("types-toml.yaml", [HttpArtifactFetcher]),
-        ("multi-output.yaml", []),
-        ("git-src.yaml", [GitArtifactFetcher]),
+        ("types-toml.yaml", {"/source/0": HttpArtifactFetcher}),
+        ("multi-output.yaml", {}),
+        ("git-src.yaml", {"/source/0": GitArtifactFetcher}),
         ## V1 Format ##
-        ("v1_format/v1_types-toml.yaml", [HttpArtifactFetcher]),
-        ("v1_format/v1_multi-output.yaml", []),
-        ("v1_format/v1_git-src.yaml", [GitArtifactFetcher]),
+        ("v1_format/v1_types-toml.yaml", {"/source/0": HttpArtifactFetcher}),
+        ("v1_format/v1_multi-output.yaml", {}),
+        ("v1_format/v1_git-src.yaml", {"/source/0": GitArtifactFetcher}),
     ],
 )
 def test_from_recipe_ignore_unsupported(
-    file: str, expected: list[Type[BaseArtifactFetcher]], request: pytest.FixtureRequest
+    file: str, expected: dict[str, Type[BaseArtifactFetcher]], request: pytest.FixtureRequest
 ) -> None:
     """
     Tests that a list of Artifact Fetchers can be derived from a parsed recipe.
@@ -41,16 +41,17 @@ def test_from_recipe_ignore_unsupported(
           `/source` path. That should be covered by recipe parsing unit tests.
 
     :param file: File to work against
-    :param expected: Expected list of classes to match the returned list.
+    :param expected: Expected mapping of source paths to classes in the returned list.
     """
     request.getfixturevalue("fs").add_real_file(get_test_path() / file)  # type: ignore[misc]
     recipe = load_recipe(file, RecipeReader)
 
-    fetcher_list: Final[list[BaseArtifactFetcher]] = from_recipe(recipe, True)
+    fetcher_map: Final[dict[str, BaseArtifactFetcher]] = from_recipe(recipe, True)
 
-    assert len(fetcher_list) == len(expected)
-    for i, fetcher in enumerate(fetcher_list):
-        assert isinstance(fetcher, expected[i])
+    assert len(fetcher_map) == len(expected)
+    for key, expected_fetcher_t in expected.items():
+        assert key in fetcher_map
+        assert isinstance(fetcher_map[key], expected_fetcher_t)
 
 
 @pytest.mark.parametrize(

--- a/tests/fetcher/test_artifact_fetcher.py
+++ b/tests/fetcher/test_artifact_fetcher.py
@@ -22,6 +22,7 @@ from tests.file_loading import get_test_path, load_recipe
     [
         ## V0 Format ##
         ("types-toml.yaml", {"/source": HttpArtifactFetcher}),
+        ("types-toml_src_lst.yaml", {"/source/0": HttpArtifactFetcher}),
         ("multi-output.yaml", {}),
         ("git-src.yaml", {"/source": GitArtifactFetcher}),
         (
@@ -35,6 +36,7 @@ from tests.file_loading import get_test_path, load_recipe
         ),
         ## V1 Format ##
         ("v1_format/v1_types-toml.yaml", {"/source": HttpArtifactFetcher}),
+        ("v1_format/v1_types-toml_src_lst.yaml", {"/source/0": HttpArtifactFetcher}),
         ("v1_format/v1_multi-output.yaml", {}),
         ("v1_format/v1_git-src.yaml", {"/source": GitArtifactFetcher}),
         (

--- a/tests/test_aux_files/bump_recipe/types-toml_build_num_1.yaml
+++ b/tests/test_aux_files/bump_recipe/types-toml_build_num_1.yaml
@@ -1,0 +1,51 @@
+{% set name = "types-toml" %}
+{% set version = "0.10.8.6" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/types-toml-{{ version }}.tar.gz
+  sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
+
+build:
+  number: 1
+  skip: true  # [py<37]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - setuptools
+    - wheel
+    - pip
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - types
+  requires:
+    - pip
+  commands:
+    - pip check
+    - test -f $SP_DIR/toml-stubs/__init__.pyi  # [unix]
+
+about:
+  home: https://github.com/python/typeshed
+  summary: Typing stubs for toml
+  description: |
+    This is a PEP 561 type stub package for the toml package.
+    It can be used by type-checking tools like mypy, pyright,
+    pytype, PyCharm, etc. to check code that uses toml.
+  license: Apache-2.0 AND MIT
+  license_file: LICENSE
+  license_family: OTHER
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://pypi.org/project/types-toml/
+
+extra:
+  recipe-maintainers:
+    - fhoehle
+    - conda-forge/mypy

--- a/tests/test_aux_files/bump_recipe/types-toml_version_bump.yaml
+++ b/tests/test_aux_files/bump_recipe/types-toml_version_bump.yaml
@@ -1,0 +1,51 @@
+{% set name = "types-toml" %}
+{% set version = "0.10.8.6" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/types-toml-{{ version }}.tar.gz
+  sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
+
+build:
+  number: 0
+  skip: true  # [py<37]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - setuptools
+    - wheel
+    - pip
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - types
+  requires:
+    - pip
+  commands:
+    - pip check
+    - test -f $SP_DIR/toml-stubs/__init__.pyi  # [unix]
+
+about:
+  home: https://github.com/python/typeshed
+  summary: Typing stubs for toml
+  description: |
+    This is a PEP 561 type stub package for the toml package.
+    It can be used by type-checking tools like mypy, pyright,
+    pytype, PyCharm, etc. to check code that uses toml.
+  license: Apache-2.0 AND MIT
+  license_file: LICENSE
+  license_family: OTHER
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://pypi.org/project/types-toml/
+
+extra:
+  recipe-maintainers:
+    - fhoehle
+    - conda-forge/mypy

--- a/tests/test_aux_files/types-toml_src_lst.yaml
+++ b/tests/test_aux_files/types-toml_src_lst.yaml
@@ -1,0 +1,51 @@
+{% set name = "types-toml" %}
+{% set version = "0.10.8.6" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/types-toml-{{ version }}.tar.gz
+    sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
+
+build:
+  number: 0
+  skip: true  # [py<37]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - setuptools
+    - wheel
+    - pip
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - types
+  requires:
+    - pip
+  commands:
+    - pip check
+    - test -f $SP_DIR/toml-stubs/__init__.pyi  # [unix]
+
+about:
+  home: https://github.com/python/typeshed
+  summary: Typing stubs for toml
+  description: |
+    This is a PEP 561 type stub package for the toml package.
+    It can be used by type-checking tools like mypy, pyright,
+    pytype, PyCharm, etc. to check code that uses toml.
+  license: Apache-2.0 AND MIT
+  license_file: LICENSE
+  license_family: OTHER
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://pypi.org/project/types-toml/
+
+extra:
+  recipe-maintainers:
+    - fhoehle
+    - conda-forge/mypy

--- a/tests/test_aux_files/v1_format/v1_types-toml_src_lst.yaml
+++ b/tests/test_aux_files/v1_format/v1_types-toml_src_lst.yaml
@@ -1,0 +1,56 @@
+schema_version: 1
+
+context:
+  name: types-toml
+  version: 0.10.8.6
+
+package:
+  name: ${{ name|lower }}
+  version: ${{ version }}
+
+source:
+  - url: https://pypi.io/packages/source/${{ name[0] }}/${{ name }}/types-toml-${{ version }}.tar.gz
+    sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
+
+build:
+  number: 0
+  skip: match(python, "<3.7")
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - setuptools
+    - wheel
+    - pip
+    - python
+  run:
+    - python
+
+tests:
+  - python:
+      imports:
+        - types
+      pip_check: true
+  - requirements:
+      run:
+        - pip
+    script:
+      - if: unix
+        then: test -f $SP_DIR/toml-stubs/__init__.pyi
+
+about:
+  summary: Typing stubs for toml
+  description: |
+    This is a PEP 561 type stub package for the toml package.
+    It can be used by type-checking tools like mypy, pyright,
+    pytype, PyCharm, etc. to check code that uses toml.
+  license: Apache-2.0 AND MIT
+  license_file: LICENSE
+  homepage: https://github.com/python/typeshed
+  repository: https://github.com/python/typeshed
+  documentation: https://pypi.org/project/types-toml/
+
+extra:
+  recipe-maintainers:
+    - fhoehle
+    - conda-forge/mypy


### PR DESCRIPTION
- `bump-recipe` now supports changing the SHA-256 hash of recipe files
  - This feature will not work as expected until the `version` is updated, which is tracked in #147 
- Adds `pytest-socket` as a test dependency to ensure our automated unit tests do not reach out to the network and spam legitimate URLs.
- Expands unit testing