### PR TITLE
168 [Remaining portion]: Change the references of the old version to the new version

### DIFF
--- a/conda_recipe_manager/commands/bump_recipe.py
+++ b/conda_recipe_manager/commands/bump_recipe.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from typing import cast
+from typing import Optional, cast
 
 import click
 
@@ -117,16 +117,29 @@ def _update_sha256(recipe_parser: RecipeParser) -> None:
 @click.command(short_help="Bumps a recipe file to a new version.")
 @click.argument("recipe_file_path", type=click.Path(exists=True, path_type=str))
 @click.option(
+    "-b",
     "--build-num",
     is_flag=True,
     help="Bump the build number by 1.",
 )
-def bump_recipe(recipe_file_path: str, build_num: bool) -> None:
+@click.option(
+    "-t",
+    "--target-version",
+    default=None,
+    type=str,
+    help="New project version to target. Required if `--build-num` is NOT specified.",
+)
+def bump_recipe(recipe_file_path: str, build_num: bool, target_version: Optional[str]) -> None:
     """
     Bumps a recipe to a new version.
 
     RECIPE_FILE_PATH: Path to the target recipe file
     """
+
+    if not build_num and target_version is None:
+        print_err("The `--target-version` option must be set if `--build-num` is not specified.")
+        sys.exit(ExitCode.CLICK_USAGE)
+
     try:
         contents_recipe = Path(recipe_file_path).read_text(encoding="utf-8")
     except IOError:

--- a/conda_recipe_manager/commands/bump_recipe.py
+++ b/conda_recipe_manager/commands/bump_recipe.py
@@ -68,7 +68,7 @@ def _update_build_num(recipe_parser: RecipeParser, increment_build_num: bool) ->
     _exit_on_failed_patch(recipe_parser, cast(JsonPatchType, {"op": "add", "path": "/build/number", "value": 0}))
 
 
-def _update_version(recipe_parser: RecipeParser, target_version: str) -> None:
+def _update_version(recipe_parser: RecipeParser, target_version: str) -> None:  # pylint: disable=unused-argument
     """
     Attempts to update the `/package/version` field and/or the commonly used `version` JINJA variable.
 

--- a/conda_recipe_manager/commands/bump_recipe.py
+++ b/conda_recipe_manager/commands/bump_recipe.py
@@ -77,20 +77,20 @@ def _update_version(recipe_parser: RecipeParser, target_version: str) -> None:
     """
     # TODO Add V0 multi-output version support for some recipes (version field is duplicated in cctools-ld64 but not in
     # most multi-output recipes)
-    # TODO branch on `/package/version` being specified without a `version` variable
+
+    # If the `version` variable is found, patch that. This is an artifact/pattern from Grayskull.
     old_variable = recipe_parser.get_variable("version", None)
     if old_variable is not None:
         recipe_parser.set_variable("version", target_version)
-        # TODO ensure that `version` is being used in `/package/version`
-        # NOTE: This is a linear search on a small list.
+        # Generate a warning if `version` is not being used in the `/package/version` field. NOTE: This is a linear
+        # search on a small list.
         if "/package/version" not in recipe_parser.get_variable_references("version"):
-            # TODO log a warning; still patch?
+            # TODO log a warning
             pass
         return
 
-    # TODO handle missing `package` field
     op: Final[str] = "replace" if recipe_parser.contains_value("/package/version") else "add"
-    recipe_parser.patch({"op": op, "path": "/package/version", "value": target_version})
+    _exit_on_failed_patch(recipe_parser, {"op": op, "path": "/package/version", "value": target_version})
 
 
 def _update_sha256(recipe_parser: RecipeParser) -> None:

--- a/conda_recipe_manager/commands/bump_recipe.py
+++ b/conda_recipe_manager/commands/bump_recipe.py
@@ -68,7 +68,7 @@ def _update_build_num(recipe_parser: RecipeParser, increment_build_num: bool) ->
     _exit_on_failed_patch(recipe_parser, cast(JsonPatchType, {"op": "add", "path": "/build/number", "value": 0}))
 
 
-def _update_version(recipe_parser: RecipeParser, target_version: str) -> None:  # pylint: disable=unused-argument
+def _update_version(recipe_parser: RecipeParser, target_version: str) -> None:
     """
     Attempts to update the `/package/version` field and/or the commonly used `version` JINJA variable.
 
@@ -83,7 +83,7 @@ def _update_version(recipe_parser: RecipeParser, target_version: str) -> None:  
         recipe_parser.set_variable("version", target_version)
         # TODO ensure that `version` is being used in `/package/version`
         # NOTE: This is a linear search on a small list.
-        if "/package/version" not in recipe_parser.get_variable_references():
+        if "/package/version" not in recipe_parser.get_variable_references("version"):
             # TODO log a warning; still patch?
             pass
         return

--- a/tests/commands/test_bump_recipe.py
+++ b/tests/commands/test_bump_recipe.py
@@ -141,7 +141,7 @@ def test_bump_recipe_exits_if_target_version_missing() -> None:
     assert result.exit_code == ExitCode.CLICK_USAGE
 
 
-def test_bump_recipe_build_number_key_missing(fs: FakeFilesystem) -> None:
+def test_bump_recipe_increment_build_number_key_missing(fs: FakeFilesystem) -> None:
     """
     Test that a `/build/number` key is added and set to 0 when it's missing.
 
@@ -162,7 +162,7 @@ def test_bump_recipe_build_number_key_missing(fs: FakeFilesystem) -> None:
     assert result.exit_code == ExitCode.SUCCESS
 
 
-def test_bump_recipe_build_number_not_int(fs: FakeFilesystem) -> None:
+def test_bump_recipe_increment_build_number_not_int(fs: FakeFilesystem) -> None:
     """
     Test that the command fails gracefully case when the build number is not an integer,
     and we are trying to increment it.
@@ -198,7 +198,7 @@ def test_bump_recipe_increment_build_num_key_not_found(fs: FakeFilesystem) -> No
     assert result.exit_code == ExitCode.SUCCESS
 
 
-def test_bump_recipe_no_build_key_found(fs: FakeFilesystem) -> None:
+def test_bump_recipe_increment_no_build_key_found(fs: FakeFilesystem) -> None:
     """
     Test that the command fails gracefully when the build key is missing and we try to revert build number to zero.
 

--- a/tests/commands/test_bump_recipe.py
+++ b/tests/commands/test_bump_recipe.py
@@ -114,7 +114,9 @@ def test_bump_recipe_cli(
     recipe_file_path = get_test_path() / recipe_file
     expected_recipe_file_path = get_test_path() / expected_recipe_file
 
-    cli_args: Final[list[str]] = ["--build-num", str(recipe_file_path)] if version is None else [str(recipe_file_path)]
+    cli_args: Final[list[str]] = (
+        ["--build-num", str(recipe_file_path)] if version is None else ["-t", version, str(recipe_file_path)]
+    )
 
     with patch("requests.get", new=mock_requests_get):
         result = runner.invoke(bump_recipe.bump_recipe, cli_args)

--- a/tests/commands/test_bump_recipe.py
+++ b/tests/commands/test_bump_recipe.py
@@ -14,7 +14,7 @@ from conda_recipe_manager.commands import bump_recipe
 from conda_recipe_manager.commands.utils.types import ExitCode
 from conda_recipe_manager.fetcher.http_artifact_fetcher import HttpArtifactFetcher
 from conda_recipe_manager.parser.recipe_reader import RecipeReader
-from tests.file_loading import get_test_path, load_recipe
+from tests.file_loading import get_test_path, load_file, load_recipe
 from tests.http_mocking import MockHttpStreamResponse
 from tests.smoke_testing import assert_cli_usage
 
@@ -125,6 +125,8 @@ def test_bump_recipe_cli(
     parser = load_recipe(recipe_file_path, RecipeReader)
     expected_parser = load_recipe(expected_recipe_file_path, RecipeReader)
 
+    # TODO figure out why this direct file comparison doesn't work
+    # assert load_file(recipe_file_path) == load_file(expected_recipe_file_path)
     assert parser == expected_parser
     assert result.exit_code == ExitCode.SUCCESS
 

--- a/tests/commands/test_bump_recipe.py
+++ b/tests/commands/test_bump_recipe.py
@@ -14,7 +14,7 @@ from conda_recipe_manager.commands import bump_recipe
 from conda_recipe_manager.commands.utils.types import ExitCode
 from conda_recipe_manager.fetcher.http_artifact_fetcher import HttpArtifactFetcher
 from conda_recipe_manager.parser.recipe_reader import RecipeReader
-from tests.file_loading import get_test_path, load_file, load_recipe
+from tests.file_loading import get_test_path, load_recipe
 from tests.http_mocking import MockHttpStreamResponse
 from tests.smoke_testing import assert_cli_usage
 
@@ -80,9 +80,9 @@ def test_usage() -> None:
 @pytest.mark.parametrize(
     "recipe_file,version,expected_recipe_file",
     [
+        # NOTE: The SHA-256 hashes will be of the mocked archive files, not of the actual source code being referenced.
         ("types-toml.yaml", None, "bump_recipe/types-toml_build_num_1.yaml"),
-        # TODO: Re-enable test when version bumping is supported.
-        # ("types-toml.yaml", "0.10.8.20240310", "bump_recipe/types-toml_version_bump.yaml"),
+        ("types-toml.yaml", "0.10.8.20240310", "bump_recipe/types-toml_version_bump.yaml"),
         # NOTE: These have no source section, therefore all SHA-256 update attempts (and associated network requests)
         # should be skipped.
         ("bump_recipe/build_num_1.yaml", None, "bump_recipe/build_num_2.yaml"),
@@ -125,8 +125,6 @@ def test_bump_recipe_cli(
     parser = load_recipe(recipe_file_path, RecipeReader)
     expected_parser = load_recipe(expected_recipe_file_path, RecipeReader)
 
-    # TODO figure out why this direct file comparison doesn't work
-    # assert load_file(recipe_file_path) == load_file(expected_recipe_file_path)
     assert parser == expected_parser
     assert result.exit_code == ExitCode.SUCCESS
 

--- a/tests/commands/test_bump_recipe.py
+++ b/tests/commands/test_bump_recipe.py
@@ -13,7 +13,6 @@ from pyfakefs.fake_filesystem import FakeFilesystem
 from conda_recipe_manager.commands import bump_recipe
 from conda_recipe_manager.commands.utils.types import ExitCode
 from conda_recipe_manager.fetcher.http_artifact_fetcher import HttpArtifactFetcher
-from conda_recipe_manager.parser.recipe_parser import RecipeParser
 from conda_recipe_manager.parser.recipe_reader import RecipeReader
 from tests.file_loading import get_test_path, load_recipe
 from tests.http_mocking import MockHttpStreamResponse
@@ -123,8 +122,8 @@ def test_bump_recipe_cli(
         result = runner.invoke(bump_recipe.bump_recipe, cli_args)
 
     # Read the edited file and check it against the expected file.
-    parser = load_recipe(recipe_file_path, RecipeParser)
-    expected_parser = load_recipe(expected_recipe_file_path, RecipeParser)
+    parser = load_recipe(recipe_file_path, RecipeReader)
+    expected_parser = load_recipe(expected_recipe_file_path, RecipeReader)
 
     assert parser == expected_parser
     assert result.exit_code == ExitCode.SUCCESS
@@ -156,8 +155,8 @@ def test_bump_recipe_build_number_key_missing(fs: FakeFilesystem) -> None:
 
     result = runner.invoke(bump_recipe.bump_recipe, ["--build-num", str(recipe_file_path)])
 
-    parser = load_recipe(recipe_file_path, RecipeParser)
-    expected_parser = load_recipe(expected_recipe_file_path, RecipeParser)
+    parser = load_recipe(recipe_file_path, RecipeReader)
+    expected_parser = load_recipe(expected_recipe_file_path, RecipeReader)
 
     assert parser == expected_parser
     assert result.exit_code == ExitCode.SUCCESS

--- a/tests/test_aux_files/bump_recipe/types-toml_version_bump.yaml
+++ b/tests/test_aux_files/bump_recipe/types-toml_version_bump.yaml
@@ -1,5 +1,5 @@
 {% set name = "types-toml" %}
-{% set version = "0.10.8.6" %}
+{% set version = "0.10.8.20240310" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/types-toml-{{ version }}.tar.gz
-  sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
+  sha256: e594f5bc141acabe4b0298d05234e80195116667edad3d6a9cd610cab36bc4e1
 
 build:
   number: 0


### PR DESCRIPTION
This is the remaining portion of the work for #168 . This completes the first-pass implementation of updating the version field.

This will not cover all edge cases, but should cover most simple Python-only recipe cases.