### PR TITLE
252 Add `sha256` variable support for `bump-recipe`

### DIFF
--- a/tests/commands/test_bump_recipe.py
+++ b/tests/commands/test_bump_recipe.py
@@ -90,7 +90,6 @@ def test_usage() -> None:
         ("gsm-amzn2-aarch64.yaml", "2.0.20210721.2", "bump_recipe/gsm-amzn2-aarch64_version_bump.yaml"),
         # Has a `sha256` variable
         ("pytest-pep8.yaml", None, "bump_recipe/pytest-pep8_build_num_2.yaml"),
-        # TODO: Fix expected file when we support the `sha256` variable
         ("pytest-pep8.yaml", "1.0.7", "bump_recipe/pytest-pep8_version_bump.yaml"),
         ("google-cloud-cpp.yaml", None, "bump_recipe/google-cloud-cpp_build_num_2.yaml"),
         ("google-cloud-cpp.yaml", "2.31.0", "bump_recipe/google-cloud-cpp_version_bump.yaml"),

--- a/tests/test_aux_files/bump_recipe/pytest-pep8_version_bump.yaml
+++ b/tests/test_aux_files/bump_recipe/pytest-pep8_version_bump.yaml
@@ -1,6 +1,6 @@
 {% set name = "pytest-pep8" %}
 {% set version = "1.0.7" %}
-{% set sha256 = "032ef7e5fa3ac30f4458c73e05bb67b0f036a8a5cb418a534b3170f89f120318" %}
+{% set sha256 = "e594f5bc141acabe4b0298d05234e80195116667edad3d6a9cd610cab36bc4e1" %}
 
 package:
   name: {{ name|lower }}
@@ -9,7 +9,7 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: e594f5bc141acabe4b0298d05234e80195116667edad3d6a9cd610cab36bc4e1
+  sha256: {{ sha256 }}
 
 build:
   noarch: python


### PR DESCRIPTION
Fixes #252 

- Recipes that contain a variable called `sha256`, `hash`, and other similar values that use that value in the `/source/sha256` for single-sourced recipe files will now update correctly. This is by far the most common case when a "hash variable" is defined.
- Lays the ground work for #255 
- Minor refactoring/reoganization
- Fixes test that was wrong until this feature was complete