### PR TITLE
255 Add cleanup function to get rid of hash type usage

### DIFF
--- a/conda_recipe_manager/parser/recipe_parser.py
+++ b/conda_recipe_manager/parser/recipe_parser.py
@@ -48,6 +48,29 @@ class RecipeParser(RecipeReader):
     # Static set of patch operations that require `from`. The others require `value` or nothing.
     _patch_ops_requiring_from = set(["copy", "move"])
 
+    ## Pre-processing Recipe Text Functions ##
+
+    @staticmethod
+    def pre_process_remove_hash_type(content: str) -> str:
+        """
+        There is a common-enough-to-be-annoying pattern used in some recipe files where the `/source/sha256` key is
+        stored as a variable. For example: `{{ hash_type }}: <hash>`
+
+        This variable-as-a-key mechanism is not supported by the parser and causes issues for other tooling. This
+        function, if run before parsing the recipe file, will remove and fix this pattern.
+
+        :param content: Recipe file contents to pre-process
+        :returns: Pre-processed recipe file contents, devoid of `hash_type` key/variable usage.
+        """
+        hash_type_var_variants: Final[set[str]] = {
+            '{% set hash_type = "sha256" %}\n',
+            '{% set hashtype = "sha256" %}\n',
+            '{% set hash = "sha256" %}\n',  # NOTE: `hash` is also commonly used for the actual SHA-256 hash value
+        }
+        for hash_type_variant in hash_type_var_variants:
+            content = content.replace(hash_type_variant, "")
+        return Regex.PRE_PROCESS_JINJA_HASH_TYPE_KEY.sub("sha256:", content)
+
     ## JINJA Variable Editing Functions ##
 
     def set_variable(self, var: str, value: JsonType) -> None:

--- a/conda_recipe_manager/parser/recipe_parser_convert.py
+++ b/conda_recipe_manager/parser/recipe_parser_convert.py
@@ -770,16 +770,7 @@ class RecipeParserConvert(RecipeParser):
         # Replace `{{ hash_type }}:` with the value of `hash_type`, which is likely `sha256`. This is an uncommon
         # practice that is not part of the V1 specification. Currently, about 70 AnacondaRecipes and conda-forge files
         # do this in our integration testing sample.
-        hash_type_var_variants: Final[set[str]] = {
-            '{% set hash_type = "sha256" %}\n',
-            '{% set hashtype = "sha256" %}\n',
-            '{% set hash = "sha256" %}\n',  # NOTE: `hash` is also commonly used for the actual SHA-256 hash value
-        }
-        for hash_type_variant in hash_type_var_variants:
-            content = content.replace(hash_type_variant, "")
-        content = Regex.PRE_PROCESS_JINJA_HASH_TYPE_KEY.sub("sha256:", content)
-
-        return content
+        return RecipeParser.pre_process_remove_hash_type(content)
 
     def render_to_v1_recipe_format(self) -> tuple[str, MessageTable, str]:
         """

--- a/tests/commands/test_bump_recipe.py
+++ b/tests/commands/test_bump_recipe.py
@@ -103,6 +103,9 @@ def test_usage() -> None:
         # NOTE: libprotobuf has multiple sources, on top of being multi-output
         ("libprotobuf.yaml", None, "bump_recipe/libprotobuf_build_num_1.yaml"),
         ("libprotobuf.yaml", "25.3", "bump_recipe/libprotobuf_version_bump.yaml"),
+        # Validates removal of `hash_type` variable that is sometimes used instead of the `/source/sha256` key
+        ("types-toml_hash_type.yaml", None, "bump_recipe/types-toml_hash_type_build_num_1.yaml"),
+        ("types-toml_hash_type.yaml", "0.10.8.20240310", "bump_recipe/types-toml_hash_type_version_bump.yaml"),
         # TODO add V1 test cases/support
         ## Version bump edge cases ##
         # NOTE: These have no source section, therefore all SHA-256 update attempts (and associated network requests)

--- a/tests/test_aux_files/bump_recipe/types-toml_hash_type_build_num_1.yaml
+++ b/tests/test_aux_files/bump_recipe/types-toml_hash_type_build_num_1.yaml
@@ -1,0 +1,52 @@
+{% set name = "types-toml" %}
+{% set version = "0.10.8.6" %}
+{% set hash = "6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/types-toml-{{ version }}.tar.gz
+  sha256: {{ hash }}
+
+build:
+  number: 1
+  skip: true  # [py<37]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - setuptools
+    - wheel
+    - pip
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - types
+  requires:
+    - pip
+  commands:
+    - pip check
+    - test -f $SP_DIR/toml-stubs/__init__.pyi  # [unix]
+
+about:
+  home: https://github.com/python/typeshed
+  summary: Typing stubs for toml
+  description: |
+    This is a PEP 561 type stub package for the toml package.
+    It can be used by type-checking tools like mypy, pyright,
+    pytype, PyCharm, etc. to check code that uses toml.
+  license: Apache-2.0 AND MIT
+  license_file: LICENSE
+  license_family: OTHER
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://pypi.org/project/types-toml/
+
+extra:
+  recipe-maintainers:
+    - fhoehle
+    - conda-forge/mypy

--- a/tests/test_aux_files/bump_recipe/types-toml_hash_type_version_bump.yaml
+++ b/tests/test_aux_files/bump_recipe/types-toml_hash_type_version_bump.yaml
@@ -1,0 +1,52 @@
+{% set name = "types-toml" %}
+{% set version = "0.10.8.20240310" %}
+{% set hash = "e594f5bc141acabe4b0298d05234e80195116667edad3d6a9cd610cab36bc4e1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/types-toml-{{ version }}.tar.gz
+  sha256: {{ hash }}
+
+build:
+  number: 0
+  skip: true  # [py<37]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - setuptools
+    - wheel
+    - pip
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - types
+  requires:
+    - pip
+  commands:
+    - pip check
+    - test -f $SP_DIR/toml-stubs/__init__.pyi  # [unix]
+
+about:
+  home: https://github.com/python/typeshed
+  summary: Typing stubs for toml
+  description: |
+    This is a PEP 561 type stub package for the toml package.
+    It can be used by type-checking tools like mypy, pyright,
+    pytype, PyCharm, etc. to check code that uses toml.
+  license: Apache-2.0 AND MIT
+  license_file: LICENSE
+  license_family: OTHER
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://pypi.org/project/types-toml/
+
+extra:
+  recipe-maintainers:
+    - fhoehle
+    - conda-forge/mypy

--- a/tests/test_aux_files/types-toml_hash_type.yaml
+++ b/tests/test_aux_files/types-toml_hash_type.yaml
@@ -1,0 +1,53 @@
+{% set name = "types-toml" %}
+{% set version = "0.10.8.6" %}
+{% set hash_type = "sha256" %}
+{% set hash = 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2 %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/types-toml-{{ version }}.tar.gz
+  {{ hash_type }}: {{ hash }}
+
+build:
+  number: 0
+  skip: true  # [py<37]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - setuptools
+    - wheel
+    - pip
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - types
+  requires:
+    - pip
+  commands:
+    - pip check
+    - test -f $SP_DIR/toml-stubs/__init__.pyi  # [unix]
+
+about:
+  home: https://github.com/python/typeshed
+  summary: Typing stubs for toml
+  description: |
+    This is a PEP 561 type stub package for the toml package.
+    It can be used by type-checking tools like mypy, pyright,
+    pytype, PyCharm, etc. to check code that uses toml.
+  license: Apache-2.0 AND MIT
+  license_file: LICENSE
+  license_family: OTHER
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://pypi.org/project/types-toml/
+
+extra:
+  recipe-maintainers:
+    - fhoehle
+    - conda-forge/mypy


### PR DESCRIPTION
- `bump-recipe` can now handle recipe files that use `hash_type` as a variable for the `/source/sha256` key
- Refactors some existing recipe conversion work to be leveraged in the `bump-recipe` command
- Adds unit tests