### PR TITLE
234 refactor canonical sorting work found in the recipeparserconvert class

### DIFF
--- a/conda_recipe_manager/parser/_types.py
+++ b/conda_recipe_manager/parser/_types.py
@@ -23,76 +23,83 @@ ROOT_NODE_VALUE: Final[str] = "/"
 # Marker used to temporarily work around some Jinja-template parsing issues
 RECIPE_MANAGER_SUB_MARKER: Final[str] = "__RECIPE_MANAGER_SUBSTITUTION_MARKER__"
 
-# Ideal sort-order of the top-level YAML keys for human readability and traditionally how we organize our files. This
-# should work on both V0 (pre CEP-13) and V1 recipe formats.
-TOP_LEVEL_KEY_SORT_ORDER: Final[dict[str, int]] = {
-    "schema_version": 0,
-    "context": 10,
-    "package": 20,
-    "recipe": 30,  # Used in the v1 recipe format
-    "source": 40,
-    "files": 50,
-    "build": 60,
-    "requirements": 70,
-    "outputs": 80,
-    "test": 90,
-    "tests": 100,  # Used in the v1 recipe format
-    "about": 110,
-    "extra": 120,
-}
 
-# Canonical sort order for the new "v1" recipe format's `build` block
-V1_SOURCE_SECTION_KEY_SORT_ORDER: Final[dict[str, int]] = {
-    # URL source fields
-    "url": 0,
-    "sha256": 10,
-    "md5": 20,
-    # Local source fields (not including above)
-    "path": 30,
-    "use_gitignore": 40,
-    # Git source fields (not including above)
-    "git": 50,
-    "branch": 60,
-    "tag": 70,
-    "rev": 80,
-    "depth": 90,
-    "lfs": 100,
-    # Common fields
-    "target_directory": 120,
-    "file_name": 130,
-    "patches": 140,
-}
+class CanonicalSortOrder:
+    """
+    Namespace that contains all canonical sort-ordering look-up tables.
+    """
 
-# Canonical sort order for the new "v1" recipe format's `build` block
-V1_BUILD_SECTION_KEY_SORT_ORDER: Final[dict[str, int]] = {
-    "number": 0,
-    "string": 10,
-    "skip": 20,
-    "noarch": 30,
-    "script": 40,
-    "merge_build_and_host_envs": 50,
-    "always_include_files": 60,
-    "always_copy_files": 70,
-    "variant": 80,
-    "python": 90,
-    "prefix_detection": 100,
-    "dynamic_linking": 110,
-}
+    # Ideal sort-order of the top-level YAML keys for human readability and traditionally how we organize our files. This
+    # should work on both V0 (pre CEP-13) and V1 recipe formats.
+    TOP_LEVEL_KEY_SORT_ORDER: Final[dict[str, int]] = {
+        "schema_version": 0,
+        "context": 10,
+        "package": 20,
+        "recipe": 30,  # Used in the v1 recipe format
+        "source": 40,
+        "files": 50,
+        "build": 60,
+        "requirements": 70,
+        "outputs": 80,
+        "test": 90,
+        "tests": 100,  # Used in the v1 recipe format
+        "about": 110,
+        "extra": 120,
+    }
 
-# Canonical sort order for the new "v1" recipe format's `tests` block
-V1_TEST_SECTION_KEY_SORT_ORDER: Final[dict[str, int]] = {
-    "script": 0,
-    "requirements": 10,
-    "files": 20,
-    "python": 30,
-    "downstream": 40,
-}
+    # Canonical sort order for the new "v1" recipe format's `build` block
+    V1_SOURCE_SECTION_KEY_SORT_ORDER: Final[dict[str, int]] = {
+        # URL source fields
+        "url": 0,
+        "sha256": 10,
+        "md5": 20,
+        # Local source fields (not including above)
+        "path": 30,
+        "use_gitignore": 40,
+        # Git source fields (not including above)
+        "git": 50,
+        "branch": 60,
+        "tag": 70,
+        "rev": 80,
+        "depth": 90,
+        "lfs": 100,
+        # Common fields
+        "target_directory": 120,
+        "file_name": 130,
+        "patches": 140,
+    }
 
-# Canonical sort order for the V1 Python test element
-V1_PYTHON_TEST_KEY_SORT_ORDER: Final[dict[str, int]] = {
-    "imports": 0,
-    "pip_check": 10,
-}
+    # Canonical sort order for the new "v1" recipe format's `build` block
+    V1_BUILD_SECTION_KEY_SORT_ORDER: Final[dict[str, int]] = {
+        "number": 0,
+        "string": 10,
+        "skip": 20,
+        "noarch": 30,
+        "script": 40,
+        "merge_build_and_host_envs": 50,
+        "always_include_files": 60,
+        "always_copy_files": 70,
+        "variant": 80,
+        "python": 90,
+        "prefix_detection": 100,
+        "dynamic_linking": 110,
+    }
+
+    # Canonical sort order for the new "v1" recipe format's `tests` block
+    V1_TEST_SECTION_KEY_SORT_ORDER: Final[dict[str, int]] = {
+        "script": 0,
+        "requirements": 10,
+        "files": 20,
+        "python": 30,
+        "downstream": 40,
+    }
+
+    # Canonical sort order for the V1 Python test element
+    V1_PYTHON_TEST_KEY_SORT_ORDER: Final[dict[str, int]] = {
+        "imports": 0,
+        "pip_check": 10,
+    }
+
 
 #### Private Classes (Not to be used external to the `parser` module) ####
 

--- a/conda_recipe_manager/parser/_types.py
+++ b/conda_recipe_manager/parser/_types.py
@@ -29,8 +29,8 @@ class CanonicalSortOrder:
     Namespace that contains all canonical sort-ordering look-up tables.
     """
 
-    # Ideal sort-order of the top-level YAML keys for human readability and traditionally how we organize our files. This
-    # should work on both V0 (pre CEP-13) and V1 recipe formats.
+    # Ideal sort-order of the top-level YAML keys for human readability and traditionally how we organize our files.
+    # This should work on both V0 (pre CEP-13) and V1 recipe formats.
     TOP_LEVEL_KEY_SORT_ORDER: Final[dict[str, int]] = {
         "schema_version": 0,
         "context": 10,

--- a/conda_recipe_manager/parser/recipe_parser.py
+++ b/conda_recipe_manager/parser/recipe_parser.py
@@ -63,8 +63,7 @@ class RecipeParser(RecipeReader):
         def _comparison(n: Node) -> int:
             return RecipeParser._canonical_sort_keys_comparison(n, tbl)
 
-        # TODO fix: need to override for Convert subclass
-        node = traverse(self._v1_recipe._root, str_to_stack_path(sort_path))  # pylint: disable=protected-access
+        node = traverse(self._root, str_to_stack_path(sort_path))  # pylint: disable=protected-access
         if node is None:
             return
         if rename:

--- a/conda_recipe_manager/parser/recipe_parser.py
+++ b/conda_recipe_manager/parser/recipe_parser.py
@@ -30,13 +30,13 @@ from conda_recipe_manager.parser._traverse import (
     traverse,
     traverse_with_index,
 )
-from conda_recipe_manager.parser._types import CanonicalSortOrder, Regex, StrStack
+from conda_recipe_manager.parser._types import Regex, StrStack
 from conda_recipe_manager.parser._utils import str_to_stack_path
 from conda_recipe_manager.parser.enums import SelectorConflictMode
 from conda_recipe_manager.parser.exceptions import JsonPatchValidationException
 from conda_recipe_manager.parser.recipe_reader import RecipeReader
 from conda_recipe_manager.parser.selector_parser import SelectorParser
-from conda_recipe_manager.parser.types import JSON_PATCH_SCHEMA, SchemaVersion
+from conda_recipe_manager.parser.types import JSON_PATCH_SCHEMA
 from conda_recipe_manager.types import PRIMITIVES_TUPLE, JsonPatchType, JsonType
 
 
@@ -69,17 +69,6 @@ class RecipeParser(RecipeReader):
         if rename:
             node.value = rename
         node.children.sort(key=_comparison)
-
-    def canonically_sort_all_keys(self) -> None:
-        """
-        TODO
-        """
-        self._sort_subtree_keys("/", CanonicalSortOrder.TOP_LEVEL_KEY_SORT_ORDER)
-        match self.get_schema_version():
-            case SchemaVersion.V0:
-                pass
-            case SchemaVersion.V1:
-                pass
 
     ## Pre-processing Recipe Text Functions ##
 

--- a/conda_recipe_manager/parser/recipe_parser_convert.py
+++ b/conda_recipe_manager/parser/recipe_parser_convert.py
@@ -9,15 +9,8 @@ from __future__ import annotations
 from typing import Final, Optional, cast
 
 from conda_recipe_manager.licenses.spdx_utils import SpdxUtils
-from conda_recipe_manager.parser._node import Node
-from conda_recipe_manager.parser._traverse import traverse
 from conda_recipe_manager.parser._types import ROOT_NODE_VALUE, CanonicalSortOrder, Regex
-from conda_recipe_manager.parser._utils import (
-    search_any_regex,
-    set_key_conditionally,
-    stack_path_to_str,
-    str_to_stack_path,
-)
+from conda_recipe_manager.parser._utils import search_any_regex, set_key_conditionally, stack_path_to_str
 from conda_recipe_manager.parser.enums import SchemaVersion
 from conda_recipe_manager.parser.recipe_parser import RecipeParser
 from conda_recipe_manager.parser.types import CURRENT_RECIPE_SCHEMA_FORMAT
@@ -313,7 +306,9 @@ class RecipeParserConvert(RecipeParser):
                 self._patch_move_base_path(src_path, "/git_depth", "/depth")
 
                 # Canonically sort this section
-                self._sort_subtree_keys(src_path, CanonicalSortOrder.V1_SOURCE_SECTION_KEY_SORT_ORDER)
+                self._v1_recipe._sort_subtree_keys(  # pylint: disable=protected-access
+                    src_path, CanonicalSortOrder.V1_SOURCE_SECTION_KEY_SORT_ORDER
+                )
 
     def _upgrade_build_script_section(self, build_path: str) -> None:
         """
@@ -453,7 +448,9 @@ class RecipeParserConvert(RecipeParser):
             self._patch_deprecated_fields(build_path, build_deprecated)
 
             # Canonically sort this section
-            self._sort_subtree_keys(build_path, CanonicalSortOrder.V1_BUILD_SECTION_KEY_SORT_ORDER)
+            self._v1_recipe._sort_subtree_keys(  # pylint: disable=protected-access
+                build_path, CanonicalSortOrder.V1_BUILD_SECTION_KEY_SORT_ORDER
+            )
 
     def _upgrade_requirements_section(self, base_package_paths: list[str]) -> None:
         """
@@ -640,7 +637,7 @@ class RecipeParserConvert(RecipeParser):
             self._patch_move_base_path(test_path, "/downstreams", "/downstream")
 
             # Canonically sort the python section, if it exists
-            self._sort_subtree_keys(
+            self._v1_recipe._sort_subtree_keys(  # pylint: disable=protected-access
                 RecipeParser.append_to_path(test_path, "/python"), CanonicalSortOrder.V1_PYTHON_TEST_KEY_SORT_ORDER
             )
 
@@ -690,7 +687,9 @@ class RecipeParserConvert(RecipeParser):
 
             # Not all the top-level keys are found in each output section, but all the output section keys are
             # found at the top-level. So for consistency, we sort on that ordering.
-            self._sort_subtree_keys(output_path, CanonicalSortOrder.TOP_LEVEL_KEY_SORT_ORDER)
+            self._v1_recipe._sort_subtree_keys(  # pylint: disable=protected-access
+                output_path, CanonicalSortOrder.TOP_LEVEL_KEY_SORT_ORDER
+            )
 
     @staticmethod
     def pre_process_recipe_text(content: str) -> str:
@@ -811,7 +810,9 @@ class RecipeParserConvert(RecipeParser):
 
         # Sort the top-level keys to a "canonical" ordering. This should make previous patch operations look more
         # "sensible" to a human reader.
-        self._sort_subtree_keys("/", CanonicalSortOrder.TOP_LEVEL_KEY_SORT_ORDER)
+        self._v1_recipe._sort_subtree_keys(  # pylint: disable=protected-access
+            "/", CanonicalSortOrder.TOP_LEVEL_KEY_SORT_ORDER
+        )
 
         # Override the schema value as the recipe conversion is now complete.
         self._v1_recipe._schema_version = SchemaVersion.V1  # pylint: disable=protected-access

--- a/conda_recipe_manager/parser/recipe_parser_convert.py
+++ b/conda_recipe_manager/parser/recipe_parser_convert.py
@@ -11,14 +11,7 @@ from typing import Final, Optional, cast
 from conda_recipe_manager.licenses.spdx_utils import SpdxUtils
 from conda_recipe_manager.parser._node import Node
 from conda_recipe_manager.parser._traverse import traverse
-from conda_recipe_manager.parser._types import (
-    ROOT_NODE_VALUE,
-    TOP_LEVEL_KEY_SORT_ORDER,
-    V1_BUILD_SECTION_KEY_SORT_ORDER,
-    V1_PYTHON_TEST_KEY_SORT_ORDER,
-    V1_SOURCE_SECTION_KEY_SORT_ORDER,
-    Regex,
-)
+from conda_recipe_manager.parser._types import ROOT_NODE_VALUE, CanonicalSortOrder, Regex
 from conda_recipe_manager.parser._utils import (
     search_any_regex,
     set_key_conditionally,
@@ -129,26 +122,6 @@ class RecipeParserConvert(RecipeParser):
                 continue
             if self._patch_and_log({"op": "remove", "path": path}):
                 self._msg_tbl.add_message(MessageCategory.WARNING, f"Field at `{path}` is no longer supported.")
-
-    def _sort_subtree_keys(self, sort_path: str, tbl: dict[str, int], rename: str = "") -> None:
-        """
-        Convenience function that sorts 1 level of keys, given a path. Optionally allows renaming of the target node.
-        No changes are made if the path provided is invalid/does not exist.
-
-        :param sort_path: Top-level path to target sorting of child keys
-        :param tbl: Table describing how keys should be sorted. Lower-value key names appear towards the top of the list
-        :param rename: (Optional) If specified, renames the top-level key
-        """
-
-        def _comparison(n: Node) -> int:
-            return RecipeParser._canonical_sort_keys_comparison(n, tbl)
-
-        node = traverse(self._v1_recipe._root, str_to_stack_path(sort_path))  # pylint: disable=protected-access
-        if node is None:
-            return
-        if rename:
-            node.value = rename
-        node.children.sort(key=_comparison)
 
     ## Upgrade functions ##
 
@@ -340,7 +313,7 @@ class RecipeParserConvert(RecipeParser):
                 self._patch_move_base_path(src_path, "/git_depth", "/depth")
 
                 # Canonically sort this section
-                self._sort_subtree_keys(src_path, V1_SOURCE_SECTION_KEY_SORT_ORDER)
+                self._sort_subtree_keys(src_path, CanonicalSortOrder.V1_SOURCE_SECTION_KEY_SORT_ORDER)
 
     def _upgrade_build_script_section(self, build_path: str) -> None:
         """
@@ -480,7 +453,7 @@ class RecipeParserConvert(RecipeParser):
             self._patch_deprecated_fields(build_path, build_deprecated)
 
             # Canonically sort this section
-            self._sort_subtree_keys(build_path, V1_BUILD_SECTION_KEY_SORT_ORDER)
+            self._sort_subtree_keys(build_path, CanonicalSortOrder.V1_BUILD_SECTION_KEY_SORT_ORDER)
 
     def _upgrade_requirements_section(self, base_package_paths: list[str]) -> None:
         """
@@ -667,7 +640,9 @@ class RecipeParserConvert(RecipeParser):
             self._patch_move_base_path(test_path, "/downstreams", "/downstream")
 
             # Canonically sort the python section, if it exists
-            self._sort_subtree_keys(RecipeParser.append_to_path(test_path, "/python"), V1_PYTHON_TEST_KEY_SORT_ORDER)
+            self._sort_subtree_keys(
+                RecipeParser.append_to_path(test_path, "/python"), CanonicalSortOrder.V1_PYTHON_TEST_KEY_SORT_ORDER
+            )
 
             # Move `test` to `tests` and encapsulate the pre-existing object into a list
             new_test_path = f"{test_path}s"
@@ -715,7 +690,7 @@ class RecipeParserConvert(RecipeParser):
 
             # Not all the top-level keys are found in each output section, but all the output section keys are
             # found at the top-level. So for consistency, we sort on that ordering.
-            self._sort_subtree_keys(output_path, TOP_LEVEL_KEY_SORT_ORDER)
+            self._sort_subtree_keys(output_path, CanonicalSortOrder.TOP_LEVEL_KEY_SORT_ORDER)
 
     @staticmethod
     def pre_process_recipe_text(content: str) -> str:
@@ -836,7 +811,7 @@ class RecipeParserConvert(RecipeParser):
 
         # Sort the top-level keys to a "canonical" ordering. This should make previous patch operations look more
         # "sensible" to a human reader.
-        self._sort_subtree_keys("/", TOP_LEVEL_KEY_SORT_ORDER)
+        self._sort_subtree_keys("/", CanonicalSortOrder.TOP_LEVEL_KEY_SORT_ORDER)
 
         # Override the schema value as the recipe conversion is now complete.
         self._v1_recipe._schema_version = SchemaVersion.V1  # pylint: disable=protected-access


### PR DESCRIPTION
Minor refactoring caused by investigate #234

The more I think about this ask, the more I think we should not do it for the sake of the user. I don't think sorting keys is as important as leaving comments in place.