### PR TITLE
243 Develop a retry mechanism for fetching artifacts in `bump-recipe`

### DIFF
--- a/conda_recipe_manager/commands/conda_recipe_manager.py
+++ b/conda_recipe_manager/commands/conda_recipe_manager.py
@@ -30,7 +30,7 @@ def conda_recipe_manager(verbose: bool) -> None:
     """
     # Initialize the logger, available to all CRM commands.
     logging.basicConfig(
-        format="[%(levelname)s] [%(name)s]: %(message)s",
+        format="%(asctime)s [%(levelname)s] [%(name)s]: %(message)s",
         level=logging.DEBUG if verbose else logging.INFO,
     )
 

--- a/conda_recipe_manager/commands/utils/types.py
+++ b/conda_recipe_manager/commands/utils/types.py
@@ -37,6 +37,7 @@ class ExitCode(IntEnum):
 
     # bump-recipe
     PATCH_ERROR = 107
+    HTTP_ERROR = 108
 
     ## rattler-bulk-build ##
     # NOTE: There may be overlap with rattler-build

--- a/conda_recipe_manager/fetcher/base_artifact_fetcher.py
+++ b/conda_recipe_manager/fetcher/base_artifact_fetcher.py
@@ -52,6 +52,14 @@ class BaseArtifactFetcher(metaclass=ABCMeta):
             return
         raise FetchRequiredError(msg)
 
+    def __str__(self) -> str:
+        """
+        Returns a simple string identifier that identifies an ArtifactFetcher instance.
+
+        :returns: String identifier (name) of the ArtifactFetcher.
+        """
+        return self._name
+
     @abstractmethod
     def fetch(self) -> None:
         """

--- a/tests/commands/test_bump_recipe.py
+++ b/tests/commands/test_bump_recipe.py
@@ -157,7 +157,7 @@ def test_bump_recipe_cli(
     "recipe_file,version,expected_retries",
     [
         ("bump_recipe/types-toml_bad_url.yaml", "0.10.8.20240310", 5),
-        # ("bump_recipe/TODOsha_retry.yaml", "0.10.8.20240310", 5),
+        ("bump_recipe/types-toml_bad_url_hash_var.yaml", "0.10.8.20240310", 5),
         # ("bump_recipe/TODO.yaml", "TODO", 10),
         # TODO validate V1 recipe files
     ],

--- a/tests/commands/test_bump_recipe.py
+++ b/tests/commands/test_bump_recipe.py
@@ -158,7 +158,9 @@ def test_bump_recipe_cli(
     [
         ("bump_recipe/types-toml_bad_url.yaml", "0.10.8.20240310", 5),
         ("bump_recipe/types-toml_bad_url_hash_var.yaml", "0.10.8.20240310", 5),
-        # ("bump_recipe/TODO.yaml", "TODO", 10),
+        # As of writing, the script will fail on the first URL that fails to be fetched, thus the count is half what
+        # one might expect.
+        ("bump_recipe/types-toml_bad_url_multi_source.yaml", "0.10.8.20240310", 5),
         # TODO validate V1 recipe files
     ],
 )
@@ -173,6 +175,7 @@ def test_bump_recipe_http_retry_mechanism(
     :param version: Version to bump to
     :param expected_retries: Expected number of retries that should have been attempted
     """
+
     runner = CliRunner()
     fs.add_real_directory(get_test_path(), read_only=False)
     recipe_file_path: Final[Path] = get_test_path() / recipe_file

--- a/tests/test_aux_files/bump_recipe/types-toml_bad_url.yaml
+++ b/tests/test_aux_files/bump_recipe/types-toml_bad_url.yaml
@@ -1,0 +1,51 @@
+{% set name = "types-toml" %}
+{% set version = "0.10.8.6" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://fake.website.total.bullshit/artifact.tar.gz
+  sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
+
+build:
+  number: 0
+  skip: true  # [py<37]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - setuptools
+    - wheel
+    - pip
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - types
+  requires:
+    - pip
+  commands:
+    - pip check
+    - test -f $SP_DIR/toml-stubs/__init__.pyi  # [unix]
+
+about:
+  home: https://github.com/python/typeshed
+  summary: Typing stubs for toml
+  description: |
+    This is a PEP 561 type stub package for the toml package.
+    It can be used by type-checking tools like mypy, pyright,
+    pytype, PyCharm, etc. to check code that uses toml.
+  license: Apache-2.0 AND MIT
+  license_file: LICENSE
+  license_family: OTHER
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://pypi.org/project/types-toml/
+
+extra:
+  recipe-maintainers:
+    - fhoehle
+    - conda-forge/mypy

--- a/tests/test_aux_files/bump_recipe/types-toml_bad_url_hash_var.yaml
+++ b/tests/test_aux_files/bump_recipe/types-toml_bad_url_hash_var.yaml
@@ -1,0 +1,53 @@
+{% set name = "types-toml" %}
+{% set version = "0.10.8.6" %}
+{% set hash_type = "sha256" %}
+{% set hash = 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2 %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://fake.website.total.bullshit/artifact.tar.gz
+  sha256: {{ hash }}
+
+build:
+  number: 0
+  skip: true  # [py<37]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - setuptools
+    - wheel
+    - pip
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - types
+  requires:
+    - pip
+  commands:
+    - pip check
+    - test -f $SP_DIR/toml-stubs/__init__.pyi  # [unix]
+
+about:
+  home: https://github.com/python/typeshed
+  summary: Typing stubs for toml
+  description: |
+    This is a PEP 561 type stub package for the toml package.
+    It can be used by type-checking tools like mypy, pyright,
+    pytype, PyCharm, etc. to check code that uses toml.
+  license: Apache-2.0 AND MIT
+  license_file: LICENSE
+  license_family: OTHER
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://pypi.org/project/types-toml/
+
+extra:
+  recipe-maintainers:
+    - fhoehle
+    - conda-forge/mypy

--- a/tests/test_aux_files/bump_recipe/types-toml_bad_url_multi_source.yaml
+++ b/tests/test_aux_files/bump_recipe/types-toml_bad_url_multi_source.yaml
@@ -1,0 +1,53 @@
+{% set name = "types-toml" %}
+{% set version = "0.10.8.6" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  - url: https://fake.website.total.bullshit/artifact2.tar.gz
+    sha256: 1d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
+  - url: https://fake.website.total.bullshit/artifact2.tar.gz
+    sha256: 2d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
+
+build:
+  number: 0
+  skip: true  # [py<37]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - setuptools
+    - wheel
+    - pip
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - types
+  requires:
+    - pip
+  commands:
+    - pip check
+    - test -f $SP_DIR/toml-stubs/__init__.pyi  # [unix]
+
+about:
+  home: https://github.com/python/typeshed
+  summary: Typing stubs for toml
+  description: |
+    This is a PEP 561 type stub package for the toml package.
+    It can be used by type-checking tools like mypy, pyright,
+    pytype, PyCharm, etc. to check code that uses toml.
+  license: Apache-2.0 AND MIT
+  license_file: LICENSE
+  license_family: OTHER
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://pypi.org/project/types-toml/
+
+extra:
+  recipe-maintainers:
+    - fhoehle
+    - conda-forge/mypy


### PR DESCRIPTION
Addresses #243 
`bump-recipe` now implements a retry mechanism when fetching HTTP artifacts, improving resilience.

Also improves:
- Logging
- Error messaging
- Code complexity in `_update_sha256()`
- Back-off interval can be customized by the `-i` flag