### PR TITLE
260 Parallelize multiple source fetch requests

### DIFF
--- a/conda_recipe_manager/commands/bump_recipe.py
+++ b/conda_recipe_manager/commands/bump_recipe.py
@@ -335,6 +335,12 @@ def _update_sha256(recipe_parser: RecipeParser, retry_interval: float) -> None:
     help="Bump the build number by 1.",
 )
 @click.option(
+    "-d",
+    "--dry-run",
+    is_flag=True,
+    help="Performs a dry-run operation that prints the recipe to STDOUT and does not save to the recipe file.",
+)
+@click.option(
     "-t",
     "--target-version",
     default=None,
@@ -353,7 +359,9 @@ def _update_sha256(recipe_parser: RecipeParser, retry_interval: float) -> None:
         f" Defaults to {_DEFAULT_RETRY_INTERVAL} seconds"
     ),
 )
-def bump_recipe(recipe_file_path: str, build_num: bool, target_version: Optional[str], retry_interval: float) -> None:
+def bump_recipe(
+    recipe_file_path: str, build_num: bool, dry_run: bool, target_version: Optional[str], retry_interval: float
+) -> None:
     """
     Bumps a recipe to a new version.
 
@@ -393,5 +401,8 @@ def bump_recipe(recipe_file_path: str, build_num: bool, target_version: Optional
         _update_version(recipe_parser, target_version)
         _update_sha256(recipe_parser, retry_interval)
 
-    Path(recipe_file_path).write_text(recipe_parser.render(), encoding="utf-8")
+    if dry_run:
+        print(recipe_parser.render())
+    else:
+        Path(recipe_file_path).write_text(recipe_parser.render(), encoding="utf-8")
     sys.exit(ExitCode.SUCCESS)

--- a/conda_recipe_manager/commands/bump_recipe.py
+++ b/conda_recipe_manager/commands/bump_recipe.py
@@ -4,8 +4,8 @@
 
 from __future__ import annotations
 
+import concurrent.futures as cf
 import logging
-import multiprocessing.pool as mp_pool
 import sys
 import time
 from pathlib import Path
@@ -247,22 +247,17 @@ def _update_sha256_check_hash_var(
     return False
 
 
-def _update_sha256_fetch_and_patch(
-    src_path: str, fetcher: HttpArtifactFetcher, retry_interval: float
-) -> tuple[str, str]:
+def _update_sha256_fetch_one(src_path: str, fetcher: HttpArtifactFetcher, retry_interval: float) -> tuple[str, str]:
     """
     Helper function that retrieves a single HTTP source artifact, so that we can parallelize network requests.
 
     :param src_path: Recipe key path to the applicable artifact source.
     :param fetcher: Artifact fetching instance to use.
     :param retry_interval: Scalable interval between fetch requests.
+    :raises FetchError: In the event that the retry mechanism failed to fetch a source artifact.
     :returns: A tuple containing the path to and the actual SHA-256 value to be updated.
     """
-    try:
-        sha = _get_sha256(fetcher, retry_interval)
-    except FetchError:
-        # TODO how does `exit` handle thread in context manager?
-        _exit_on_failed_fetch(fetcher)
+    sha = _get_sha256(fetcher, retry_interval)
     return (RecipeParser.append_to_path(src_path, "/sha256"), sha)
 
 
@@ -295,16 +290,23 @@ def _update_sha256(recipe_parser: RecipeParser, retry_interval: float) -> None:
     http_fetcher_tbl: Final[dict[str, HttpArtifactFetcher]] = {
         k: v for k, v in fetcher_tbl.items() if isinstance(v, HttpArtifactFetcher)
     }
-    # Parallelize on acquiring multiple source artifacts on the network. In testing, using the process Pool took ~9
-    # seconds and used significantly more resources than using the ThreadPool took ~2 seconds. This test simulated a
-    # recipe with 15 sources. Because this process is so I/O bound, the ThreadPool class is the way to go.
-    with mp_pool.ThreadPool() as pool:
-        sha_path_to_sha_tbl = dict(
-            pool.starmap(
-                _update_sha256_fetch_and_patch,
-                [(src_path, fetcher, retry_interval) for src_path, fetcher in http_fetcher_tbl.items()],
-            )
-        )
+    # Parallelize on acquiring multiple source artifacts on the network. In testing, using a process pool took
+    # significantly more time and resources. That aligns with how I/O bound this process is. We use the
+    # `ThreadPoolExecutor` class over a `ThreadPool` so the script may exit gracefully if we failed to acquire an
+    # artifact.
+    sha_path_to_sha_tbl: dict[str, str] = {}
+    with cf.ThreadPoolExecutor() as executor:
+        artifact_futures_tbl = {
+            executor.submit(_update_sha256_fetch_one, src_path, fetcher, retry_interval): fetcher
+            for src_path, fetcher in http_fetcher_tbl.items()
+        }
+        for future in cf.as_completed(artifact_futures_tbl):
+            fetcher = artifact_futures_tbl[future]
+            try:
+                resolved_tuple = future.result()
+                sha_path_to_sha_tbl[resolved_tuple[0]] = resolved_tuple[1]
+            except FetchError:
+                _exit_on_failed_fetch(fetcher)
 
     for sha_path, sha in sha_path_to_sha_tbl.items():
         unique_hashes.add(sha)

--- a/tests/commands/test_bump_recipe.py
+++ b/tests/commands/test_bump_recipe.py
@@ -158,9 +158,8 @@ def test_bump_recipe_cli(
     [
         ("bump_recipe/types-toml_bad_url.yaml", "0.10.8.20240310", 5),
         ("bump_recipe/types-toml_bad_url_hash_var.yaml", "0.10.8.20240310", 5),
-        # As of writing, the script will fail on the first URL that fails to be fetched, thus the count is half what
-        # one might expect.
-        ("bump_recipe/types-toml_bad_url_multi_source.yaml", "0.10.8.20240310", 5),
+        # Note that with futures, all 10 (5 by 2 sources) should occur by the time the futures are fully resolved.
+        ("bump_recipe/types-toml_bad_url_multi_source.yaml", "0.10.8.20240310", 10),
         # TODO validate V1 recipe files
     ],
 )

--- a/tests/commands/test_bump_recipe.py
+++ b/tests/commands/test_bump_recipe.py
@@ -87,6 +87,7 @@ def test_usage() -> None:
         # Does not use `version` variable, has a non-zero build number. Note that the URL is not parameterized on the
         # version field.
         ("gsm-amzn2-aarch64.yaml", None, "bump_recipe/gsm-amzn2-aarch64_build_num_6.yaml"),
+        # TODO Fix this slow test tracked by Issue #265
         ("gsm-amzn2-aarch64.yaml", "2.0.20210721.2", "bump_recipe/gsm-amzn2-aarch64_version_bump.yaml"),
         # Has a `sha256` variable
         ("pytest-pep8.yaml", None, "bump_recipe/pytest-pep8_build_num_2.yaml"),
@@ -102,6 +103,7 @@ def test_usage() -> None:
         ("curl.yaml", "8.11.0", "bump_recipe/curl_version_bump.yaml"),
         # NOTE: libprotobuf has multiple sources, on top of being multi-output
         ("libprotobuf.yaml", None, "bump_recipe/libprotobuf_build_num_1.yaml"),
+        # TODO Fix this slow test tracked by Issue #265
         ("libprotobuf.yaml", "25.3", "bump_recipe/libprotobuf_version_bump.yaml"),
         # Validates removal of `hash_type` variable that is sometimes used instead of the `/source/sha256` key
         ("types-toml_hash_type.yaml", None, "bump_recipe/types-toml_hash_type_build_num_1.yaml"),


### PR DESCRIPTION
We now use futures to download multiple source files concurrently.

Also introduces a `--dry-run` mode that dumps the recipe file to STDOUT instead of overwriting the recipe file.

~~Putting this PR up as a Draft until I can figure out why some of the `bump_recipe_cli` tests are significantly slower after this change (causing the tests to take 4 seconds to 35 seconds).~~ That issue is now tracked in #265 as it appears to have no known user impact and is tied to the test environment.