### PR TITLE
244 bump recipe should exit and save gracefully on some failures

### DIFF
--- a/conda_recipe_manager/commands/bump_recipe.py
+++ b/conda_recipe_manager/commands/bump_recipe.py
@@ -359,8 +359,22 @@ def _update_sha256(recipe_parser: RecipeParser, retry_interval: float) -> None:
         f" Defaults to {_DEFAULT_RETRY_INTERVAL} seconds"
     ),
 )
+@click.option(
+    "-s",
+    "--save-on-failure",
+    is_flag=True,
+    help=(
+        "Saves the current state of the recipe file in the event of a failure."
+        " In other words, the file may only contain some automated edits."
+    ),
+)
 def bump_recipe(
-    recipe_file_path: str, build_num: bool, dry_run: bool, target_version: Optional[str], retry_interval: float
+    recipe_file_path: str,
+    build_num: bool,
+    dry_run: bool,
+    target_version: Optional[str],
+    retry_interval: float,
+    save_on_failure: bool,
 ) -> None:
     """
     Bumps a recipe to a new version.

--- a/tests/commands/test_bump_recipe.py
+++ b/tests/commands/test_bump_recipe.py
@@ -295,7 +295,9 @@ def test_bump_recipe_save_on_failure(
     start_mod_time: Final[float] = recipe_file_path.stat().st_mtime
 
     with patch("requests.get", new=mock_requests_get):
-        result = runner.invoke(bump_recipe.bump_recipe, ["--save-on-failure", "-t", version, str(recipe_file_path)])
+        result = runner.invoke(
+            bump_recipe.bump_recipe, ["--save-on-failure", "-i", "0.01", "-t", version, str(recipe_file_path)]
+        )
 
     # Ensure the file was written by checking the modification timestamp. Some tests may not have any changes if the
     # error occurred too soon.

--- a/tests/commands/test_bump_recipe.py
+++ b/tests/commands/test_bump_recipe.py
@@ -265,3 +265,41 @@ def test_bump_recipe_increment_no_build_key_found(fs: FakeFilesystem) -> None:
     recipe_file_path: Final[Path] = get_test_path() / "bump_recipe/no_build_key.yaml"
     result = runner.invoke(bump_recipe.bump_recipe, ["--build-num", str(recipe_file_path)])
     assert result.exit_code == ExitCode.ILLEGAL_OPERATION
+
+
+@pytest.mark.parametrize(
+    "recipe_file,version,expected_recipe_file",
+    [
+        ("bump_recipe/types-toml_bad_url.yaml", "0.10.8.20240310", "bump_recipe/types-toml_bad_url_partial_save.yaml"),
+        # Build number is the first thing attempted, so no changes will be made to the file. Instead will check the
+        # modification time.
+        ("bump_recipe/no_build_key.yaml", "0.10.8.20240310", "bump_recipe/no_build_key.yaml"),
+    ],
+)
+def test_bump_recipe_save_on_failure(
+    fs: FakeFilesystem, recipe_file: str, version: str, expected_recipe_file: str
+) -> None:
+    """
+    Ensures that recipes that encounter a problem can be partially saved with the `--save-on-failure` option.
+
+    :param fs: `pyfakefs` Fixture used to replace the file system
+    :param recipe_file: Target recipe file to update
+    :param version: Version to bump to
+    :param expected_recipe_file: Expected resulting recipe file
+    """
+    runner = CliRunner()
+    fs.add_real_directory(get_test_path(), read_only=False)
+
+    recipe_file_path: Final[Path] = get_test_path() / recipe_file
+    expected_recipe_file_path: Final[Path] = get_test_path() / expected_recipe_file
+    start_mod_time: Final[float] = recipe_file_path.stat().st_mtime
+
+    with patch("requests.get", new=mock_requests_get):
+        result = runner.invoke(bump_recipe.bump_recipe, ["--save-on-failure", "-t", version, str(recipe_file_path)])
+
+    # Ensure the file was written by checking the modification timestamp. Some tests may not have any changes if the
+    # error occurred too soon.
+    assert recipe_file_path.stat().st_mtime > start_mod_time
+    # Read the edited file and check it against the expected file. We don't parse the recipe file as it isn't necessary.
+    assert load_file(recipe_file_path) == load_file(expected_recipe_file_path)
+    assert result.exit_code != ExitCode.SUCCESS

--- a/tests/test_aux_files/bump_recipe/types-toml_bad_url_partial_save.yaml
+++ b/tests/test_aux_files/bump_recipe/types-toml_bad_url_partial_save.yaml
@@ -1,5 +1,5 @@
 {% set name = "types-toml" %}
-{% set version = "0.10.8.6" %}
+{% set version = "0.10.8.20240310" %}
 
 package:
   name: {{ name|lower }}
@@ -10,7 +10,7 @@ source:
   sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
 
 build:
-  number: 1
+  number: 0
   skip: true  # [py<37]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 


### PR DESCRIPTION
Adds a new `--save-on-failure` flag to `crm bump-recipe` to allow the tool to save partially upgraded files, in the event of an unrecoverable failure.

Also simplifies adding future flags by introducing a `_CliArgs` struct to easily pass new flags into all necessary functions going forward.