### PR TITLE
`conda-forge::` removed from environment.yaml

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -10,7 +10,7 @@ dependencies:
   - python >=3.11
   - pytest
   - pytest-cov
-  - conda-forge::pytest-socket
+  - pytest-socket
   - pytest-xdist
   - pyfakefs
   # Match version with .pre-commit-config.yaml to ensure consistent rules with `make lint`.


### PR DESCRIPTION
`pytest-socket` is now widely available on both `conda-forge` and `defaults`, allowing us to make this change.