### PR TITLE
Addresses #289

### DIFF
--- a/conda_recipe_manager/parser/recipe_parser_convert.py
+++ b/conda_recipe_manager/parser/recipe_parser_convert.py
@@ -642,15 +642,16 @@ class RecipeParserConvert(RecipeParserDeps):
 
         :param test_path: Test path for the build target to upgrade
         """
+        # Replace `- pip check` in `commands` with the new flag. If not found, set the flag to `False` (as the
+        # flag defaults to `True`). DO NOT ADD THIS FLAG IF THE RECIPE IS NOT A "PYTHON RECIPE".
+        if not self._v1_recipe.is_python_recipe():
+            return
+
         pip_check_variants: Final[set[str]] = {
             "pip check",
             "python -m pip check",
             "python3 -m pip check",
         }
-        # Replace `- pip check` in `commands` with the new flag. If not found, set the flag to `False` (as the
-        # flag defaults to `True`). DO NOT ADD THIS FLAG IF THE RECIPE IS NOT A "PYTHON RECIPE".
-        if not self._v1_recipe.is_python_recipe():
-            return
 
         commands_path: Final[str] = RecipeParser.append_to_path(test_path, "/commands")
         commands = cast(Optional[list[str]], self._v1_recipe.get_value(commands_path, []))

--- a/conda_recipe_manager/parser/recipe_reader.py
+++ b/conda_recipe_manager/parser/recipe_reader.py
@@ -970,9 +970,16 @@ class RecipeReader(IsModifiable):
         """
         # TODO cache this or otherwise find a way to reduce the computation complexity.
         # TODO consider making a single query interface similar to `RecipeReaderDeps::get_all_dependencies()`
-        # TODO improve definition/validation of "pure Python". Right now, we simply check if Python is a host dependency
-        # which will likely be sufficient for the vast majority of cases.
+        # TODO improve definition/validation of "pure Python"
         for base_path in self.get_package_paths():
+            # A "pure python" package shouldn't need a `build` dependencies.
+            build_deps = cast(
+                Optional[list[str | dict[str, str]]],
+                self.get_value(RecipeReader.append_to_path(base_path, "/requirements/build"), default=[]),
+            )
+            if build_deps:
+                return False
+
             host_path = RecipeReader.append_to_path(base_path, "/requirements/host")
             host_deps = cast(Optional[list[str | dict[str, str]]], self.get_value(host_path, default=[]))
             # Skip the rare edge case where the list may be null (usually caused by commented-out code)

--- a/tests/parser/test_recipe_parser_convert.py
+++ b/tests/parser/test_recipe_parser_convert.py
@@ -24,6 +24,8 @@ from tests.file_loading import load_file, load_recipe
         ("quoted_multiline_str.yaml", "pre_processor/pp_quoted_multiline_str.yaml"),
         # Issue #271 environ.get() conversions
         ("unprocessed_environ_get.yaml", "pre_processor/pp_environ_get.yaml"),
+        # Min/max pin upgrades to new upper/lower bound syntax
+        ("min_max_pin.yaml", "pre_processor/pp_min_max_pin.yaml"),
         # Unchanged file
         ("simple-recipe.yaml", "simple-recipe.yaml"),
     ],
@@ -236,8 +238,8 @@ def test_pre_process_recipe_text(input_file: str, expected_file: str) -> None:
                 "Field at `/about/license_family` is no longer supported.",
             ],
         ),
-        # Regression test for Issue 289. Compiled projects that use Python are not "pure python" packages. Such packages
-        # should not receive a Python section with a `pip_check: False` field
+        # Issue #289: Compiled projects that use Python are not "pure python" packages. Such packages should not receive
+        # a Python section with a `pip_check: False` field
         (
             "issue_289_regression.yaml",
             [],

--- a/tests/parser/test_recipe_parser_convert.py
+++ b/tests/parser/test_recipe_parser_convert.py
@@ -236,6 +236,21 @@ def test_pre_process_recipe_text(input_file: str, expected_file: str) -> None:
                 "Field at `/about/license_family` is no longer supported.",
             ],
         ),
+        # Regression test for Issue 289. Compiled projects that use Python are not "pure python" packages. Such packages
+        # should not receive a Python section with a `pip_check: False` field
+        (
+            "issue_289_regression.yaml",
+            [],
+            [
+                "Recipe upgrades cannot currently upgrade ambiguous version constraints on dependencies that"
+                " use variables: ${{ stdlib('c') }}",
+                "Recipe upgrades cannot currently upgrade ambiguous version constraints on dependencies that"
+                " use variables: ${{ compiler('c') }}",
+                "Recipe upgrades cannot currently upgrade ambiguous version constraints on dependencies that"
+                " use variables: ${{ compiler('cxx') }}",
+                "Field at `/about/license_family` is no longer supported.",
+            ],
+        ),
         # TODO complete: The `rust.yaml` test contains many edge cases and selectors that aren't directly supported in
         # the V1 recipe format
         # (

--- a/tests/parser/test_recipe_reader.py
+++ b/tests/parser/test_recipe_reader.py
@@ -1001,6 +1001,9 @@ def test_is_multi_output(file: str, expected: bool) -> None:
         ("v1_format/v1_types-toml.yaml", True),
         ("v1_format/v1_boto.yaml", True),
         ("v1_format/v1_cctools-ld64.yaml", False),
+        # Regression test for Issue 289. Compiled projects that use Python are not "pure python" packages.
+        ("issue_289_regression.yaml", False),
+        ("v1_format/v1_issue_289_regression.yaml", False),
     ],
 )
 def test_is_python_recipe(file: str, expected: bool) -> None:

--- a/tests/test_aux_files/issue_289_regression.yaml
+++ b/tests/test_aux_files/issue_289_regression.yaml
@@ -1,0 +1,58 @@
+{% set name = "su2" %}
+{% set version = "8.1.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/su2code/SU2/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: d550be60ccc8cb907d53a0531715b229585f1e92e2e8e22ab2e8a181d096e7c9
+  patches:
+    - su2-meson.patch
+
+build:
+  skip: True  # [win or osx]
+  number: 0
+
+requirements:
+  build:
+    - make
+    - {{ stdlib('c') }}
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - pkg-config
+    - ccache
+    - swig
+  host:
+    - python
+    - mpi4py
+    - openblas
+    - openmpi
+    - zlib
+  run:
+    - python
+    - libopenblas
+    - openmpi
+
+test:
+  commands:
+    - SU2_CFD --help
+    # The following items have no `--help` and require config file to be run
+    - test -x ${PREFIX}/bin/SU2_DEF
+    - test -x ${PREFIX}/bin/SU2_DOT
+    - test -x ${PREFIX}/bin/SU2_GEO
+    - test -x ${PREFIX}/bin/SU2_SOL
+
+about:
+  home: https://su2code.github.io
+  license: GPL-2.0-or-later
+  license_family: GPL
+  license_file: LICENSE.md
+  summary: An Open-Source Suite for Multiphysics Simulation and Design
+  doc_url: https://su2code.github.io/docs_v7/home/
+  dev_url: https://github.com/su2code/SU2
+
+extra:
+  recipe-maintainers:
+    - martin-g

--- a/tests/test_aux_files/min_max_pin.yaml
+++ b/tests/test_aux_files/min_max_pin.yaml
@@ -1,0 +1,4 @@
+requirements:
+  run:
+    - ${{ pin_subpackage(name, min_pin='x') }}
+    - ${{ pin_subpackage(name, max_pin='y') }}

--- a/tests/test_aux_files/pre_processor/pp_min_max_pin.yaml
+++ b/tests/test_aux_files/pre_processor/pp_min_max_pin.yaml
@@ -1,0 +1,4 @@
+requirements:
+  run:
+    - ${{ pin_subpackage(name, lower_bound='x') }}
+    - ${{ pin_subpackage(name, upper_bound='y') }}

--- a/tests/test_aux_files/v1_format/v1_issue_289_regression.yaml
+++ b/tests/test_aux_files/v1_format/v1_issue_289_regression.yaml
@@ -1,0 +1,59 @@
+schema_version: 1
+
+context:
+  name: su2
+  version: 8.1.0
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://github.com/su2code/SU2/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: d550be60ccc8cb907d53a0531715b229585f1e92e2e8e22ab2e8a181d096e7c9
+  patches:
+    - su2-meson.patch
+
+build:
+  number: 0
+  skip: win or osx
+
+requirements:
+  build:
+    - make
+    - ${{ stdlib('c') }}
+    - ${{ compiler('c') }}
+    - ${{ compiler('cxx') }}
+    - pkg-config
+    - ccache
+    - swig
+  host:
+    - python
+    - mpi4py
+    - openblas
+    - openmpi
+    - zlib
+  run:
+    - python
+    - libopenblas
+    - openmpi
+
+tests:
+  - script:
+      - SU2_CFD --help
+      - test -x ${PREFIX}/bin/SU2_DEF
+      - test -x ${PREFIX}/bin/SU2_DOT
+      - test -x ${PREFIX}/bin/SU2_GEO
+      - test -x ${PREFIX}/bin/SU2_SOL
+
+about:
+  license: GPL-2.0-or-later
+  license_file: LICENSE.md
+  summary: An Open-Source Suite for Multiphysics Simulation and Design
+  homepage: https://su2code.github.io
+  repository: https://github.com/su2code/SU2
+  documentation: https://su2code.github.io/docs_v7/home/
+
+extra:
+  recipe-maintainers:
+    - martin-g


### PR DESCRIPTION
- Fixes #289 by adjusting logic in `RecipeReader::is_python_recipe()`
- Adds a regression test for #289
- Adds a missing test for upgrading to newer `upper/lower` bound syntax.