### PR TITLE
Add `--version` flag to crm

### DIFF
--- a/conda_recipe_manager/commands/conda_recipe_manager.py
+++ b/conda_recipe_manager/commands/conda_recipe_manager.py
@@ -24,6 +24,7 @@ from conda_recipe_manager.commands.rattler_bulk_build import rattler_bulk_build
     show_default=True,
     help="Enables verbose logging (for commands that use the logger).",
 )
+@click.version_option()
 def conda_recipe_manager(verbose: bool) -> None:
     """
     Command line interface for conda recipe management commands.


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Use `click`'s built in `@click.version_option()` decorator to add the `--version` flag. 

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->



<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/conda-recipe-manager/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda-incubator/conda-recipe-manager/blob/main/CONTRIBUTING.md -->
