### PR TITLE
Mitigates the test slow down described by #265

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,3 +146,4 @@ Here is a brief overview of our current release process:
 - @cbouss for his work on the [Percy project](https://github.com/anaconda/percy) that originally inspired the recipe parser.
 - @akabanovs for his work and experimentation on package dependency graph building.
 - @JeanChristopheMorinPerso for his PR review contributions when this project was a part of `Percy` and answering questions about the `conda` file formats.
+- @mrbean-bremen for maintaining the `pyfakefs` project and for providing guidance and assistance with `pyfakefs`.

--- a/tests/commands/test_bump_recipe.py
+++ b/tests/commands/test_bump_recipe.py
@@ -144,6 +144,10 @@ def test_bump_recipe_cli(
     cli_args: Final[list[str]] = (
         ["--build-num", str(recipe_file_path)] if version is None else ["-t", version, str(recipe_file_path)]
     )
+    # We should not need to set a retry limit on valid mocked HTTP calls. But this mitigates the retry mechanism from
+    # slowing down the tests. This problem is described by Issue #265.
+    # Special thanks to @mrbean-bremen for assisting with this investigation.
+    cli_args.extend(["--retry-interval", "0.001"])
 
     with patch("requests.get", new=mock_requests_get):
         result = runner.invoke(bump_recipe.bump_recipe, cli_args)


### PR DESCRIPTION
- Adds a retry flag to the slow test to mitigate the slow down described by Issue #265. Special thanks to @mrbean-bremen for suggesting this.
- Adds discovery documentation to highlight why we are doing this.
