### PR TITLE
Adds parser support for `| replace` evaluation

### DIFF
--- a/conda_recipe_manager/parser/_types.py
+++ b/conda_recipe_manager/parser/_types.py
@@ -197,10 +197,12 @@ class Regex:
 
     # All recognized JINJA functions are kept in a set for the convenience of trying to match against all of them.
     # Group 1 contains the function or variable name, Group 2 contains the arguments, if any.
+    # NOTE: `| replace()` and `.replace()` are both valid in V0 and common. `.upper()` and `.lower()` are VERY uncommon,
+    # but are trivial to support. In V1, `| <func>` is the only acceptable form.
     JINJA_FUNCTION_LOWER: Final[re.Pattern[str]] = re.compile(r"\|\s*(lower)")
     JINJA_FUNCTION_UPPER: Final[re.Pattern[str]] = re.compile(r"\|\s*(upper)")
     JINJA_FUNCTION_REPLACE: Final[re.Pattern[str]] = re.compile(
-        r"""\|\s*(replace)\(['"](.*)['"]\s*,\s*['"](.*)['"]\)"""
+        r"""[\|\.]\s*(replace)\(['"](.*)['"]\s*,\s*['"](.*)['"]\)"""
     )
     JINJA_FUNCTION_IDX_ACCESS: Final[re.Pattern[str]] = re.compile(r"(\w+)\[(\d+)\]")
     JINJA_FUNCTION_ADD_CONCAT: Final[re.Pattern[str]] = re.compile(

--- a/conda_recipe_manager/parser/_types.py
+++ b/conda_recipe_manager/parser/_types.py
@@ -199,8 +199,8 @@ class Regex:
     # Group 1 contains the function or variable name, Group 2 contains the arguments, if any.
     # NOTE: `| replace()` and `.replace()` are both valid in V0 and common. `.upper()` and `.lower()` are VERY uncommon,
     # but are trivial to support. In V1, `| <func>` is the only acceptable form.
-    JINJA_FUNCTION_LOWER: Final[re.Pattern[str]] = re.compile(r"\|\s*(lower)")
-    JINJA_FUNCTION_UPPER: Final[re.Pattern[str]] = re.compile(r"\|\s*(upper)")
+    JINJA_FUNCTION_LOWER: Final[re.Pattern[str]] = re.compile(r"\|\s*(lower)|\.(lower)\(\)")
+    JINJA_FUNCTION_UPPER: Final[re.Pattern[str]] = re.compile(r"\|\s*(upper)|\.(upper)\(\)")
     JINJA_FUNCTION_REPLACE: Final[re.Pattern[str]] = re.compile(
         r"""[\|\.]\s*(replace)\(['"](.*)['"]\s*,\s*['"](.*)['"]\)"""
     )

--- a/conda_recipe_manager/parser/_types.py
+++ b/conda_recipe_manager/parser/_types.py
@@ -199,7 +199,9 @@ class Regex:
     # Group 1 contains the function or variable name, Group 2 contains the arguments, if any.
     JINJA_FUNCTION_LOWER: Final[re.Pattern[str]] = re.compile(r"\|\s*(lower)")
     JINJA_FUNCTION_UPPER: Final[re.Pattern[str]] = re.compile(r"\|\s*(upper)")
-    JINJA_FUNCTION_REPLACE: Final[re.Pattern[str]] = re.compile(r"\|\s*(replace)\((.*)\)")
+    JINJA_FUNCTION_REPLACE: Final[re.Pattern[str]] = re.compile(
+        r"""\|\s*(replace)\(['"](.*)['"]\s*,\s*['"](.*)['"]\)"""
+    )
     JINJA_FUNCTION_IDX_ACCESS: Final[re.Pattern[str]] = re.compile(r"(\w+)\[(\d+)\]")
     JINJA_FUNCTION_ADD_CONCAT: Final[re.Pattern[str]] = re.compile(
         r"([\"\']?[\w\.]+[\"\']?)\s*\+\s*([\"\']?[\w\.]+[\"\']?)"

--- a/tests/parser/test_recipe_reader.py
+++ b/tests/parser/test_recipe_reader.py
@@ -648,6 +648,7 @@ def test_contains_value(file: str, path: str, expected: bool) -> None:
         # Replace cases
         ("sub_vars.yaml", "/requirements/fake_run_constrained/17", True, "TYPES_toml"),
         ("sub_vars.yaml", "/requirements/fake_run_constrained/18", True, "types_toml"),
+        ("sub_vars.yaml", "/requirements/fake_run_constrained/19", True, "TYPES_toml"),
         ## v1_simple-recipe.yaml ##
         ("v1_format/v1_simple-recipe.yaml", "/build/number", False, 0),
         ("v1_format/v1_simple-recipe.yaml", "/build/number/", False, 0),
@@ -805,6 +806,7 @@ def test_contains_value(file: str, path: str, expected: bool) -> None:
         ("v1_format/v1_sub_vars.yaml", "/requirements/fake_run_constrained/16", True, "foo > 6"),
         ("v1_format/v1_sub_vars.yaml", "/requirements/fake_run_constrained/17", True, "TYPES_toml"),
         ("v1_format/v1_sub_vars.yaml", "/requirements/fake_run_constrained/18", True, "types_toml"),
+        ("v1_format/v1_sub_vars.yaml", "/requirements/fake_run_constrained/19", True, "TYPES_toml"),
         # Replace cases
         ## multi-output.yaml ##
         ("multi-output.yaml", "/outputs/0/build/run_exports/0", False, "bar"),

--- a/tests/parser/test_recipe_reader.py
+++ b/tests/parser/test_recipe_reader.py
@@ -645,6 +645,9 @@ def test_contains_value(file: str, path: str, expected: bool) -> None:
         ("sub_vars.yaml", "/requirements/fake_run_constrained/14", True, "dne42"),
         ("sub_vars.yaml", "/requirements/fake_run_constrained/15", True, 'foo > "42"'),
         ("sub_vars.yaml", "/requirements/fake_run_constrained/16", True, "foo > 6"),
+        # Replace cases
+        ("sub_vars.yaml", "/requirements/fake_run_constrained/17", True, "TYPES_toml"),
+        ("sub_vars.yaml", "/requirements/fake_run_constrained/18", True, "types_toml"),
         ## v1_simple-recipe.yaml ##
         ("v1_format/v1_simple-recipe.yaml", "/build/number", False, 0),
         ("v1_format/v1_simple-recipe.yaml", "/build/number/", False, 0),
@@ -800,6 +803,9 @@ def test_contains_value(file: str, path: str, expected: bool) -> None:
         ("v1_format/v1_sub_vars.yaml", "/requirements/fake_run_constrained/14", True, "dne42"),
         ("v1_format/v1_sub_vars.yaml", "/requirements/fake_run_constrained/15", True, 'foo > "42"'),
         ("v1_format/v1_sub_vars.yaml", "/requirements/fake_run_constrained/16", True, "foo > 6"),
+        ("v1_format/v1_sub_vars.yaml", "/requirements/fake_run_constrained/17", True, "TYPES_toml"),
+        ("v1_format/v1_sub_vars.yaml", "/requirements/fake_run_constrained/18", True, "types_toml"),
+        # Replace cases
         ## multi-output.yaml ##
         ("multi-output.yaml", "/outputs/0/build/run_exports/0", False, "bar"),
         ("multi-output.yaml", "/outputs/0/build/run_exports", False, ["bar"]),

--- a/tests/parser/test_recipe_reader.py
+++ b/tests/parser/test_recipe_reader.py
@@ -649,6 +649,8 @@ def test_contains_value(file: str, path: str, expected: bool) -> None:
         ("sub_vars.yaml", "/requirements/fake_run_constrained/17", True, "TYPES_toml"),
         ("sub_vars.yaml", "/requirements/fake_run_constrained/18", True, "types_toml"),
         ("sub_vars.yaml", "/requirements/fake_run_constrained/19", True, "TYPES_toml"),
+        ("sub_vars.yaml", "/requirements/fake_run_constrained/20", True, "types_toml"),
+        ("sub_vars.yaml", "/requirements/fake_run_constrained/21", True, "TYPES_TOML"),
         ## v1_simple-recipe.yaml ##
         ("v1_format/v1_simple-recipe.yaml", "/build/number", False, 0),
         ("v1_format/v1_simple-recipe.yaml", "/build/number/", False, 0),
@@ -807,6 +809,8 @@ def test_contains_value(file: str, path: str, expected: bool) -> None:
         ("v1_format/v1_sub_vars.yaml", "/requirements/fake_run_constrained/17", True, "TYPES_toml"),
         ("v1_format/v1_sub_vars.yaml", "/requirements/fake_run_constrained/18", True, "types_toml"),
         ("v1_format/v1_sub_vars.yaml", "/requirements/fake_run_constrained/19", True, "TYPES_toml"),
+        ("v1_format/v1_sub_vars.yaml", "/requirements/fake_run_constrained/20", True, "types_toml"),
+        ("v1_format/v1_sub_vars.yaml", "/requirements/fake_run_constrained/21", True, "TYPES_TOML"),
         # Replace cases
         ## multi-output.yaml ##
         ("multi-output.yaml", "/outputs/0/build/run_exports/0", False, "bar"),

--- a/tests/test_aux_files/sub_vars.yaml
+++ b/tests/test_aux_files/sub_vars.yaml
@@ -44,8 +44,9 @@ requirements:
     - {{ dne + 42 }}
     - foo > {{ '4' + "2" }}
     - foo > {{ 4 + 2 }}
-    - {{ name|replace("-", "_")}}
-    - {{ name | lower | replace('-', '_')}}
+    - {{ name|replace("-", "_") }}
+    - {{ name | lower | replace('-', '_') }}
+    - {{ name.replace('-', '_') }}
 
 test:
   imports:

--- a/tests/test_aux_files/sub_vars.yaml
+++ b/tests/test_aux_files/sub_vars.yaml
@@ -44,6 +44,8 @@ requirements:
     - {{ dne + 42 }}
     - foo > {{ '4' + "2" }}
     - foo > {{ 4 + 2 }}
+    - {{ name|replace("-", "_")}}
+    - {{ name | lower | replace('-', '_')}}
 
 test:
   imports:

--- a/tests/test_aux_files/sub_vars.yaml
+++ b/tests/test_aux_files/sub_vars.yaml
@@ -47,6 +47,8 @@ requirements:
     - {{ name|replace("-", "_") }}
     - {{ name | lower | replace('-', '_') }}
     - {{ name.replace('-', '_') }}
+    - {{ name.lower().replace('-', '_') }}
+    - {{ name.upper().replace('-', '_') }}
 
 test:
   imports:

--- a/tests/test_aux_files/v1_format/v1_sub_vars.yaml
+++ b/tests/test_aux_files/v1_format/v1_sub_vars.yaml
@@ -50,6 +50,8 @@ requirements:
     - ${{ name|replace("-", "_") }}
     - ${{ name | lower | replace('-', '_') }}
     - ${{ name.replace('-', '_') }}
+    - ${{ name.lower().replace('-', '_') }}
+    - ${{ name.upper().replace('-', '_') }}
 
 tests:
   - python:

--- a/tests/test_aux_files/v1_format/v1_sub_vars.yaml
+++ b/tests/test_aux_files/v1_format/v1_sub_vars.yaml
@@ -47,6 +47,8 @@ requirements:
     - ${{ dne + 42 }}
     - foo > ${{ '4' + "2" }}
     - foo > ${{ 4 + 2 }}
+    - ${{ name|replace("-", "_")}}
+    - ${{ name | lower | replace('-', '_')}}
 
 tests:
   - python:

--- a/tests/test_aux_files/v1_format/v1_sub_vars.yaml
+++ b/tests/test_aux_files/v1_format/v1_sub_vars.yaml
@@ -47,8 +47,9 @@ requirements:
     - ${{ dne + 42 }}
     - foo > ${{ '4' + "2" }}
     - foo > ${{ 4 + 2 }}
-    - ${{ name|replace("-", "_")}}
-    - ${{ name | lower | replace('-', '_')}}
+    - ${{ name|replace("-", "_") }}
+    - ${{ name | lower | replace('-', '_') }}
+    - ${{ name.replace('-', '_') }}
 
 tests:
   - python:


### PR DESCRIPTION
Fixes #321

As a bonus, the parser can now evaluate `.replace()`, `.upper()`, and `.lower()`.

This should greatly increase accuracy when evaluating source URLs in recipe files.