### PR TITLE
Some more JINJA variable support improvements

### DIFF
--- a/conda_recipe_manager/parser/_types.py
+++ b/conda_recipe_manager/parser/_types.py
@@ -220,8 +220,11 @@ class Regex:
         JINJA_FUNCTION_LOWER,
         JINJA_FUNCTION_UPPER,
         JINJA_FUNCTION_REPLACE,
-        JINJA_FUNCTION_SPLIT,
-        JINJA_FUNCTION_JOIN,
+        # TODO FIX: Adding `split` and `join` to this list causes some odd bracket-escaping in the
+        # `regression_jinja_sub.yaml` upgrade test. This will require additional investigation, but for now, IMO the
+        # old behavior is a little less wrong, so we'll leave it as is.
+        # JINJA_FUNCTION_SPLIT,
+        # JINJA_FUNCTION_JOIN,
         JINJA_FUNCTION_IDX_ACCESS,
         JINJA_FUNCTION_ADD_CONCAT,
         JINJA_FUNCTION_MATCH,

--- a/conda_recipe_manager/parser/_types.py
+++ b/conda_recipe_manager/parser/_types.py
@@ -210,7 +210,7 @@ class Regex:
     JINJA_FUNCTION_JOIN: Final[re.Pattern[str]] = re.compile(
         r"""\|\s*(join)\(['"]([^'"]*)['"]\)|['"]([^'"]*)['"]\.(join)\((.*)\)"""
     )
-    JINJA_FUNCTION_IDX_ACCESS: Final[re.Pattern[str]] = re.compile(r"(.+)\[(\d+)\]")
+    JINJA_FUNCTION_IDX_ACCESS: Final[re.Pattern[str]] = re.compile(r"(.+)\[(-?\d+)\]")
     JINJA_FUNCTION_ADD_CONCAT: Final[re.Pattern[str]] = re.compile(
         r"([\"\']?[\w\.]+[\"\']?)\s*\+\s*([\"\']?[\w\.]+[\"\']?)"
     )

--- a/conda_recipe_manager/parser/_types.py
+++ b/conda_recipe_manager/parser/_types.py
@@ -204,6 +204,8 @@ class Regex:
     JINJA_FUNCTION_REPLACE: Final[re.Pattern[str]] = re.compile(
         r"""[\|\.]\s*(replace)\(['"](.*)['"]\s*,\s*['"](.*)['"]\)"""
     )
+    JINJA_FUNCTION_SPLIT: Final[re.Pattern[str]] = re.compile(r"""[\|\.]\s*(split)\(['"](.*)['"]\)""")
+    JINJA_FUNCTION_JOIN: Final[re.Pattern[str]] = re.compile(r"""[\|\.]\s*(join)\(['"](.*)['"]\)""")
     JINJA_FUNCTION_IDX_ACCESS: Final[re.Pattern[str]] = re.compile(r"(\w+)\[(\d+)\]")
     JINJA_FUNCTION_ADD_CONCAT: Final[re.Pattern[str]] = re.compile(
         r"([\"\']?[\w\.]+[\"\']?)\s*\+\s*([\"\']?[\w\.]+[\"\']?)"
@@ -214,6 +216,8 @@ class Regex:
         JINJA_FUNCTION_LOWER,
         JINJA_FUNCTION_UPPER,
         JINJA_FUNCTION_REPLACE,
+        JINJA_FUNCTION_SPLIT,
+        JINJA_FUNCTION_JOIN,
         JINJA_FUNCTION_IDX_ACCESS,
         JINJA_FUNCTION_ADD_CONCAT,
         JINJA_FUNCTION_MATCH,

--- a/conda_recipe_manager/parser/_types.py
+++ b/conda_recipe_manager/parser/_types.py
@@ -202,11 +202,15 @@ class Regex:
     JINJA_FUNCTION_LOWER: Final[re.Pattern[str]] = re.compile(r"\|\s*(lower)|\.(lower)\(\)")
     JINJA_FUNCTION_UPPER: Final[re.Pattern[str]] = re.compile(r"\|\s*(upper)|\.(upper)\(\)")
     JINJA_FUNCTION_REPLACE: Final[re.Pattern[str]] = re.compile(
-        r"""[\|\.]\s*(replace)\(['"](.*)['"]\s*,\s*['"](.*)['"]\)"""
+        r"""[\|\.]\s*(replace)\(['"]([^'"]*)['"]\s*,\s*['"]([^'"]*)['"]\)"""
     )
-    JINJA_FUNCTION_SPLIT: Final[re.Pattern[str]] = re.compile(r"""[\|\.]\s*(split)\(['"](.*)['"]\)""")
-    JINJA_FUNCTION_JOIN: Final[re.Pattern[str]] = re.compile(r"""[\|\.]\s*(join)\(['"](.*)['"]\)""")
-    JINJA_FUNCTION_IDX_ACCESS: Final[re.Pattern[str]] = re.compile(r"(\w+)\[(\d+)\]")
+    JINJA_FUNCTION_SPLIT: Final[re.Pattern[str]] = re.compile(r"""[\|\.]\s*(split)\(['"]([^'"]*)['"]\)""")
+    # NOTE: `join` doesn't follow the same pattern as the other JINJA regular expressions. The function name can be in
+    # one of two group locations.
+    JINJA_FUNCTION_JOIN: Final[re.Pattern[str]] = re.compile(
+        r"""\|\s*(join)\(['"]([^'"]*)['"]\)|['"]([^'"]*)['"]\.(join)\((.*)\)"""
+    )
+    JINJA_FUNCTION_IDX_ACCESS: Final[re.Pattern[str]] = re.compile(r"(.+)\[(\d+)\]")
     JINJA_FUNCTION_ADD_CONCAT: Final[re.Pattern[str]] = re.compile(
         r"([\"\']?[\w\.]+[\"\']?)\s*\+\s*([\"\']?[\w\.]+[\"\']?)"
     )

--- a/conda_recipe_manager/parser/recipe_reader.py
+++ b/conda_recipe_manager/parser/recipe_reader.py
@@ -261,22 +261,28 @@ class RecipeReader(IsModifiable):
         :param key: Sanitized key to perform JINJA functions on.
         :returns: The modified key, if any JINJA functions apply. Also returns any applicable match objects.
         """
-        # TODO add support for REPLACE
+
+        # Helper function that strips-out JINJA ops out of the string, `key`.
+        def _strip_op(k: str, m: Optional[re.Match[str]]) -> str:
+            if not m:
+                return k
+            return k.replace(m.group(), "").strip()
 
         # Example: {{ name | lower }}
         lower_match = Regex.JINJA_FUNCTION_LOWER.search(key)
-        if lower_match:
-            key = key.replace(lower_match.group(), "").strip()
+        key = _strip_op(key, lower_match)
 
         # Example: {{ name | upper }}
         upper_match = Regex.JINJA_FUNCTION_UPPER.search(key)
-        if upper_match:
-            key = key.replace(upper_match.group(), "").strip()
+        key = _strip_op(key, upper_match)
 
         # Example: {{ name | replace('-', '_') }
         replace_match = Regex.JINJA_FUNCTION_REPLACE.search(key)
-        if replace_match:
-            key = key.replace(replace_match.group(), "").strip()
+        key = _strip_op(key, replace_match)
+
+        # Example: {{ name | split('.') }
+        split_match = Regex.JINJA_FUNCTION_SPLIT.search(key)
+        key = _strip_op(key, split_match)
 
         # Example: {{ name[0] }}
         idx_match = Regex.JINJA_FUNCTION_IDX_ACCESS.search(key)

--- a/conda_recipe_manager/parser/recipe_reader.py
+++ b/conda_recipe_manager/parser/recipe_reader.py
@@ -407,8 +407,8 @@ class RecipeReader(IsModifiable):
                     idx = int(cast(str, idx_match.group(2)))
                     # From our research, it looks like string indexing on JINJA variables is almost exclusively used
                     # get the first character in a string. If the index is out of bounds, we will default to the
-                    # variable's value as a fall-back.
-                    if 0 <= idx < len(value):
+                    # variable's value as a fall-back. Although rare, negative indexing is supported.
+                    if -len(value) <= idx < len(value):
                         value = value[idx]
                 if replace_match:
                     value = value.replace(replace_match.group(2), replace_match.group(3))

--- a/conda_recipe_manager/parser/recipe_reader.py
+++ b/conda_recipe_manager/parser/recipe_reader.py
@@ -253,6 +253,8 @@ class RecipeReader(IsModifiable):
         Optional[re.Match[str]],
         Optional[re.Match[str]],
         Optional[re.Match[str]],
+        Optional[re.Match[str]],
+        Optional[re.Match[str]],
     ]:
         """
         Helper function for `_render_jinja_vars()` that takes a JINJA statement (string inside the braces) and attempts
@@ -282,19 +284,45 @@ class RecipeReader(IsModifiable):
 
         # Example: {{ name | split('.') }
         split_match = Regex.JINJA_FUNCTION_SPLIT.search(key)
-        key = _strip_op(key, split_match)
+        # Example: {{ '.'.join(version.split(".")[:2]) }}
+        join_match = Regex.JINJA_FUNCTION_JOIN.search(key)
 
         # Example: {{ name[0] }}
         idx_match = Regex.JINJA_FUNCTION_IDX_ACCESS.search(key)
         if idx_match:
             key = key.replace(f"[{cast(str, idx_match.group(2))}]", "").strip()
 
+        # NOTE: `split` and `join` are special. `split` changes the type from a string to a list and `join` requires
+        # a list to work as expected. As a workaround, we only apply `split` if a `join` or `index` operation is
+        # present. Additionally, we only apply a `join` if a `split` is present.
+        if split_match and join_match:
+            key = _strip_op(key, split_match)
+            # Re-calculate the join's match now that `split` has been removed.
+            join_match = Regex.JINJA_FUNCTION_JOIN.search(key)
+            if join_match:
+                # If we are in the | form, remove the `join()` portion entirely
+                if join_match.groups()[0] is not None:
+                    key = _strip_op(key, join_match)
+                # If we are in the `.` form, extract the key from the `.join()` call.
+                else:
+                    key = join_match.group(5)
+            # This should not be possible, but we still want to guard against accidental list evaluation if a `join` is
+            # no longer possible.
+            else:
+                join_match = None
+                split_match = None
+        elif split_match and idx_match:
+            key = _strip_op(key, split_match)
+        else:
+            join_match = None
+            split_match = None
+
         # Addition/concatenation. Note the key(s) will need to be evaluated later.
         # Example: {{ build_number + 100 }}
         # Example: {{ version + ".1" }}
         add_concat_match = Regex.JINJA_FUNCTION_ADD_CONCAT.search(key)
 
-        return key, lower_match, upper_match, replace_match, idx_match, add_concat_match
+        return key, lower_match, upper_match, replace_match, split_match, join_match, idx_match, add_concat_match
 
     def _eval_jinja_token(self, s: str) -> JsonType:
         """
@@ -325,7 +353,7 @@ class RecipeReader(IsModifiable):
 
     def _render_jinja_vars(self, s: str) -> JsonType:
         # pylint: disable=too-complex
-        # TODO Refactor and simplify ^
+        # TODO Refactor and simplify. We should really consider using a proper parser over REGEX soup.
         """
         Helper function that replaces Jinja substitutions with their actual set values.
 
@@ -343,7 +371,7 @@ class RecipeReader(IsModifiable):
             # The regex guarantees the string starts and ends with double braces
             key = match[start_idx:-2].strip()
             # Check for and interpret common JINJA functions
-            key, lower_match, upper_match, replace_match, idx_match, add_concat_match = (
+            key, lower_match, upper_match, replace_match, split_match, join_match, idx_match, add_concat_match = (
                 RecipeReader._set_key_and_matches(key)
             )
 
@@ -365,6 +393,16 @@ class RecipeReader(IsModifiable):
                     value = value.lower()
                 if upper_match:
                     value = value.upper()
+                # NOTE: We previously guarantee in `_set_key_and_matches()` that `split` is accompanied by a operation
+                # that will normalize it back to a string. But for this to work, we must perform the `split` before a
+                # `join` or an index access.
+                if split_match:
+                    value = value.split(split_match.group(2))  # type: ignore[assignment]
+                if join_match:
+                    # The index of the string that we join on changes depending on which form of the function is used.
+                    # NOTE: `.groups()` does not return the top-level 0th grouping, so the indices are 1-off.
+                    join_str_idx = 3 if join_match.groups()[2] is not None else 2
+                    value = join_match.group(join_str_idx).join(value)
                 if idx_match:
                     idx = int(cast(str, idx_match.group(2)))
                     # From our research, it looks like string indexing on JINJA variables is almost exclusively used

--- a/tests/parser/test_recipe_reader.py
+++ b/tests/parser/test_recipe_reader.py
@@ -657,6 +657,9 @@ def test_contains_value(file: str, path: str, expected: bool) -> None:
         ("sub_vars.yaml", "/requirements/fake_run_constrained/24", True, "TYPES.toml"),
         ("sub_vars.yaml", "/requirements/fake_run_constrained/25", True, "TYPES"),
         ("sub_vars.yaml", "/requirements/fake_run_constrained/26", True, "TYPES.toml"),
+        ("sub_vars.yaml", "/requirements/fake_run_constrained/27", True, "l"),
+        ("sub_vars.yaml", "/requirements/fake_run_constrained/28", True, "T"),
+        ("sub_vars.yaml", "/requirements/fake_run_constrained/29", True, "TYPES-toml"),
         ## v1_simple-recipe.yaml ##
         ("v1_format/v1_simple-recipe.yaml", "/build/number", False, 0),
         ("v1_format/v1_simple-recipe.yaml", "/build/number/", False, 0),
@@ -824,6 +827,9 @@ def test_contains_value(file: str, path: str, expected: bool) -> None:
         ("v1_format/v1_sub_vars.yaml", "/requirements/fake_run_constrained/24", True, "TYPES.toml"),
         ("v1_format/v1_sub_vars.yaml", "/requirements/fake_run_constrained/25", True, "TYPES"),
         ("v1_format/v1_sub_vars.yaml", "/requirements/fake_run_constrained/26", True, "TYPES.toml"),
+        ("v1_format/v1_sub_vars.yaml", "/requirements/fake_run_constrained/27", True, "l"),
+        ("v1_format/v1_sub_vars.yaml", "/requirements/fake_run_constrained/28", True, "T"),
+        ("v1_format/v1_sub_vars.yaml", "/requirements/fake_run_constrained/29", True, "TYPES-toml"),
         ## multi-output.yaml ##
         ("multi-output.yaml", "/outputs/0/build/run_exports/0", False, "bar"),
         ("multi-output.yaml", "/outputs/0/build/run_exports", False, ["bar"]),

--- a/tests/parser/test_recipe_reader.py
+++ b/tests/parser/test_recipe_reader.py
@@ -651,6 +651,12 @@ def test_contains_value(file: str, path: str, expected: bool) -> None:
         ("sub_vars.yaml", "/requirements/fake_run_constrained/19", True, "TYPES_toml"),
         ("sub_vars.yaml", "/requirements/fake_run_constrained/20", True, "types_toml"),
         ("sub_vars.yaml", "/requirements/fake_run_constrained/21", True, "TYPES_TOML"),
+        # Complex split and join cases. Note that we do not replace if split/join would result in a non-string value.
+        ("sub_vars.yaml", "/requirements/fake_run_constrained/22", True, "${{ name.split('-') }}"),
+        ("sub_vars.yaml", "/requirements/fake_run_constrained/23", True, "${{ '.'.join(name) }}"),
+        ("sub_vars.yaml", "/requirements/fake_run_constrained/24", True, "TYPES.toml"),
+        ("sub_vars.yaml", "/requirements/fake_run_constrained/25", True, "TYPES"),
+        ("sub_vars.yaml", "/requirements/fake_run_constrained/26", True, "TYPES.toml"),
         ## v1_simple-recipe.yaml ##
         ("v1_format/v1_simple-recipe.yaml", "/build/number", False, 0),
         ("v1_format/v1_simple-recipe.yaml", "/build/number/", False, 0),
@@ -806,12 +812,18 @@ def test_contains_value(file: str, path: str, expected: bool) -> None:
         ("v1_format/v1_sub_vars.yaml", "/requirements/fake_run_constrained/14", True, "dne42"),
         ("v1_format/v1_sub_vars.yaml", "/requirements/fake_run_constrained/15", True, 'foo > "42"'),
         ("v1_format/v1_sub_vars.yaml", "/requirements/fake_run_constrained/16", True, "foo > 6"),
+        # Replace cases
         ("v1_format/v1_sub_vars.yaml", "/requirements/fake_run_constrained/17", True, "TYPES_toml"),
         ("v1_format/v1_sub_vars.yaml", "/requirements/fake_run_constrained/18", True, "types_toml"),
         ("v1_format/v1_sub_vars.yaml", "/requirements/fake_run_constrained/19", True, "TYPES_toml"),
         ("v1_format/v1_sub_vars.yaml", "/requirements/fake_run_constrained/20", True, "types_toml"),
         ("v1_format/v1_sub_vars.yaml", "/requirements/fake_run_constrained/21", True, "TYPES_TOML"),
-        # Replace cases
+        # Complex split and join cases. Note that we do not replace if split/join would result in a non-string value.
+        ("v1_format/v1_sub_vars.yaml", "/requirements/fake_run_constrained/22", True, "${{ name.split('-') }}"),
+        ("v1_format/v1_sub_vars.yaml", "/requirements/fake_run_constrained/23", True, "${{ '.'.join(name) }}"),
+        ("v1_format/v1_sub_vars.yaml", "/requirements/fake_run_constrained/24", True, "TYPES.toml"),
+        ("v1_format/v1_sub_vars.yaml", "/requirements/fake_run_constrained/25", True, "TYPES"),
+        ("v1_format/v1_sub_vars.yaml", "/requirements/fake_run_constrained/26", True, "TYPES.toml"),
         ## multi-output.yaml ##
         ("multi-output.yaml", "/outputs/0/build/run_exports/0", False, "bar"),
         ("multi-output.yaml", "/outputs/0/build/run_exports", False, ["bar"]),

--- a/tests/test_aux_files/sub_vars.yaml
+++ b/tests/test_aux_files/sub_vars.yaml
@@ -54,6 +54,9 @@ requirements:
     - {{ '.'.join(name.split('-')) }}
     - {{ name.split('-')[0] }}
     - {{ name | split('-') | join('.') }}
+    - {{ name[-1] }}
+    - {{ name[-10] }}
+    - {{ name[-11] }}
 
 test:
   imports:

--- a/tests/test_aux_files/sub_vars.yaml
+++ b/tests/test_aux_files/sub_vars.yaml
@@ -49,6 +49,11 @@ requirements:
     - {{ name.replace('-', '_') }}
     - {{ name.lower().replace('-', '_') }}
     - {{ name.upper().replace('-', '_') }}
+    - {{ name.split('-') }}
+    - {{ '.'.join(name) }}
+    - {{ '.'.join(name.split('-')) }}
+    - {{ name.split('-')[0] }}
+    - {{ name | split('-') | join('.') }}
 
 test:
   imports:

--- a/tests/test_aux_files/v1_format/v1_sub_vars.yaml
+++ b/tests/test_aux_files/v1_format/v1_sub_vars.yaml
@@ -52,6 +52,11 @@ requirements:
     - ${{ name.replace('-', '_') }}
     - ${{ name.lower().replace('-', '_') }}
     - ${{ name.upper().replace('-', '_') }}
+    - ${{ name.split('-') }}
+    - ${{ '.'.join(name) }}
+    - ${{ '.'.join(name.split('-')) }}
+    - ${{ name.split('-')[0] }}
+    - ${{ name | split('-') | join('.') }}
 
 tests:
   - python:

--- a/tests/test_aux_files/v1_format/v1_sub_vars.yaml
+++ b/tests/test_aux_files/v1_format/v1_sub_vars.yaml
@@ -57,6 +57,9 @@ requirements:
     - ${{ '.'.join(name.split('-')) }}
     - ${{ name.split('-')[0] }}
     - ${{ name | split('-') | join('.') }}
+    - ${{ name[-1] }}
+    - ${{ name[-10] }}
+    - ${{ name[-11] }}
 
 tests:
   - python:


### PR DESCRIPTION
- Adds some initial support for `join` and `split` statements.
- Also allows for Python-style negative indexing. This is rare but does happen in recipe files.