### PR TITLE
Migrates `conda-incubator` --> `conda`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # Syntax for this file at https://help.github.com/articles/about-codeowners/
 
-*   @conda-incubator/builds-tools
+*   @conda/builds-tools

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,5 +18,5 @@
      let us know!
 
      Helpful links:
-       - Conda Org COC: https://github.com/conda-incubator/conda-recipe-manager/blob/main/CODE_OF_CONDUCT.md
-       - Contributing docs: https://github.com/conda-incubator/conda-recipe-manager/blob/main/CONTRIBUTING.md -->
+       - Conda Org COC: https://github.com/conda/conda-recipe-manager/blob/main/CODE_OF_CONDUCT.md
+       - Contributing docs: https://github.com/conda/conda-recipe-manager/blob/main/CONTRIBUTING.md -->

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
-          repository: conda-incubator/conda-recipe-manager-test-data
+          repository: conda/conda-recipe-manager-test-data
           path: test_data
           sparse-checkout: recipes_v0/${{ matrix.test-directory }}
       - uses: ./.github/actions/setup-env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ Some highlights:
 - Adds `pyfakefs` to the unit testing suite.
 
 Full changelog available at:
-https://github.com/conda-incubator/conda-recipe-manager/compare/v0.2.1...v0.3.0
+https://github.com/conda/conda-recipe-manager/compare/v0.2.1...v0.3.0
 
 ## 0.2.1
 Minor bug fixes and documentation improvements. Conversion compatibility with Bioconda recipe has improved significantly.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-[commit-checks-badge]: https://github.com/conda-incubator/conda-recipe-manager/actions/workflows/commit_checks.yaml/badge.svg?branch=main
-[integration-tests-badge]: https://github.com/conda-incubator/conda-recipe-manager/actions/workflows/integration_tests.yaml/badge.svg?branch=main
-[release-badge]: https://img.shields.io/github/v/release/conda-incubator/conda-recipe-manager?logo=github
+[commit-checks-badge]: https://github.com/conda/conda-recipe-manager/actions/workflows/commit_checks.yaml/badge.svg?branch=main
+[integration-tests-badge]: https://github.com/conda/conda-recipe-manager/actions/workflows/integration_tests.yaml/badge.svg?branch=main
+[release-badge]: https://img.shields.io/github/v/release/conda/conda-recipe-manager?logo=github
 
 
 # `conda-recipe-manager`
 
-[![Commit Checks][commit-checks-badge]](https://github.com/conda-incubator/conda-recipe-manager/actions/workflows/commit_checks.yaml)
-[![Integration Tests][integration-tests-badge]](https://github.com/conda-incubator/conda-recipe-manager/actions/workflows/integration_tests.yaml)
-[![GitHub Release][release-badge]](https://github.com/conda-incubator/conda-recipe-manager/releases)
+[![Commit Checks][commit-checks-badge]](https://github.com/conda/conda-recipe-manager/actions/workflows/commit_checks.yaml)
+[![Integration Tests][integration-tests-badge]](https://github.com/conda/conda-recipe-manager/actions/workflows/integration_tests.yaml)
+[![GitHub Release][release-badge]](https://github.com/conda/conda-recipe-manager/releases)
 
 # Overview
 Conda Recipe Manager (CRM) is a library and tool-set capable of managing `conda` recipe files. It is intended
@@ -21,9 +21,9 @@ For a more comprehensive break-down and status of the library modules, see
 
 ## Recipe Compatibility
 The latest recipe-parsing compatibility statistics can be found in the summary of our automated
-[Integration Tests](https://github.com/conda-incubator/conda-recipe-manager/actions).
+[Integration Tests](https://github.com/conda/conda-recipe-manager/actions).
 
-Our integration test data set is available [here](https://github.com/conda-incubator/conda-recipe-manager-test-data)
+Our integration test data set is available [here](https://github.com/conda/conda-recipe-manager-test-data)
 and is based off of publicly available recipe files from various sources.
 
 NOTE: CRM only officially supports recipe files in the V0. There is on-going work to add full support for editing
@@ -105,7 +105,7 @@ conda activate conda-recipe-manager
 
 ### Developer Documentation
 We aim for a very high bar when it comes to code documentation so that we may leverage automatic documentation
-workflows. API docs are hosted [here](https://conda-incubator.github.io/conda-recipe-manager/index.html)
+workflows. API docs are hosted [here](https://conda.github.io/conda-recipe-manager/index.html)
 
 ### Setup Troubleshooting
 - If you are currently in the `conda-recipe-manager` environment, make sure that you exit the environment with

--- a/conda_recipe_manager/parser/recipe_parser_convert.py
+++ b/conda_recipe_manager/parser/recipe_parser_convert.py
@@ -863,8 +863,8 @@ class RecipeParserConvert(RecipeParserDeps):
         state.
 
         This "new" format is defined in the following CEPs:
-          - https://github.com/conda-incubator/ceps/blob/main/cep-13.md
-          - https://github.com/conda-incubator/ceps/blob/main/cep-14.md
+          - https://github.com/conda/ceps/blob/main/cep-0013.md
+          - https://github.com/conda/ceps/blob/main/cep-0014.md
 
         :returns: Returns a tuple containing: - The converted recipe, as a string - A `MessageTbl` instance that
             contains error logging - Converted recipe file debug string. USE FOR DEBUGGING PURPOSES ONLY!

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,7 +10,7 @@ by package builders and developers to automate the generation and editing of con
 
 This website acts as an API document for using conda-recipe-manager in other projects. For details about how to use
 the CLI tools provided by this project or how to contribute to this project directly, please visit the
-`CRM GitHub repository <https://github.com/conda-incubator/conda-recipe-manager>`_.
+`CRM GitHub repository <https://github.com/conda/conda-recipe-manager>`_.
 
 Contents
 ========

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,12 +51,12 @@ test:
     - python -m pytest -n auto --ignore=tests/test_aux_files tests/
 
 about:
-  home: https://github.com/conda-incubator/conda-recipe-manager
+  home: https://github.com/conda/conda-recipe-manager
   license: BSD-3-Clause
   license_file: LICENSE
-  license_url: https://github.com/conda-incubator/conda-recipe-manager/blob/main/LICENSE
+  license_url: https://github.com/conda/conda-recipe-manager/blob/main/LICENSE
   summary: Helper tool for recipes on aggregate.
   description: |
     Renders local recipes, provides build orders, find outdated recipes.
-  doc_url: https://conda-incubator.github.io/conda-recipe-manager/index.html
-  dev_url: https://github.com/conda-incubator/conda-recipe-manager
+  doc_url: https://conda.github.io/conda-recipe-manager/index.html
+  dev_url: https://github.com/conda/conda-recipe-manager

--- a/tests/parser/test_pickle_integration.py
+++ b/tests/parser/test_pickle_integration.py
@@ -52,7 +52,7 @@ def test_pickle_integration_recipe_parsers(file: str, constructor: Callable[[str
     the thread pool tooling available in `multiprocessing`.
 
     More details about this problem can be found in this PR:
-      https://github.com/conda-incubator/conda-recipe-manager/pull/105
+      https://github.com/conda/conda-recipe-manager/pull/105
     """
     file_text = load_file(file)
     parser = constructor(file_text)

--- a/tests/test_aux_files/git-src.yaml
+++ b/tests/test_aux_files/git-src.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  git_url: https://github.com/conda-incubator/conda-recipe-manager.git
+  git_url: https://github.com/conda/conda-recipe-manager.git
   git_tag: v1.0.0
   git_rev: 1
   git_depth: 0

--- a/tests/test_aux_files/rg_from_disk_test/v1_git-src/recipe.yaml
+++ b/tests/test_aux_files/rg_from_disk_test/v1_git-src/recipe.yaml
@@ -10,7 +10,7 @@ package:
 
 source:
   sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
-  git: https://github.com/conda-incubator/conda-recipe-manager.git
+  git: https://github.com/conda/conda-recipe-manager.git
   tag: v1.0.0
   rev: 1
   depth: 0

--- a/tests/test_aux_files/v1_format/v1_git-src.yaml
+++ b/tests/test_aux_files/v1_format/v1_git-src.yaml
@@ -10,7 +10,7 @@ package:
 
 source:
   sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
-  git: https://github.com/conda-incubator/conda-recipe-manager.git
+  git: https://github.com/conda/conda-recipe-manager.git
   tag: v1.0.0
   rev: 1
   depth: 0


### PR DESCRIPTION
Changes applicable URLs and other references now that this project has moved to the GH conda org.