### PR TITLE
convert: support build.force_use_keys, build.ignore_run_exports_from

### DIFF
--- a/conda_recipe_manager/parser/recipe_parser_convert.py
+++ b/conda_recipe_manager/parser/recipe_parser_convert.py
@@ -501,13 +501,19 @@ class RecipeParserConvert(RecipeParserDeps):
                     self._patch_and_log({"op": "add", "path": requirements_path, "value": None})
                 self._patch_and_log({"op": "move", "from": old_re_path, "path": new_re_path})
             # `ignore_run_exports`
-            old_ire_path = RecipeParser.append_to_path(base_path, "/build/ignore_run_exports")
-            if self._v1_recipe.contains_value(old_ire_path):
-                requirements_path = RecipeParser.append_to_path(base_path, "/requirements")
-                new_ire_path = RecipeParser.append_to_path(base_path, "/requirements/ignore_run_exports")
-                if not self._v1_recipe.contains_value(requirements_path):
-                    self._patch_and_log({"op": "add", "path": requirements_path, "value": None})
-                self._patch_and_log({"op": "move", "from": old_ire_path, "path": new_ire_path})
+            for old_ire_name, new_ire_name in [
+                ("ignore_run_exports", "by_name"),
+                ("ignore_run_exports_from", "from_package"),
+            ]:
+                old_ire_path = RecipeParser.append_to_path(base_path, f"/build/{old_ire_name}")
+                if self._v1_recipe.contains_value(old_ire_path):
+                    self._patch_add_missing_path(base_path, "/requirements")
+                    self._patch_move_new_path(
+                        base_path,
+                        f"/build/{old_ire_name}",
+                        "/requirements/ignore_run_exports",
+                        new_ire_name,
+                    )
 
             # Perform internal section changes per `build/` section
             build_path = RecipeParser.append_to_path(base_path, "/build")
@@ -520,6 +526,9 @@ class RecipeParserConvert(RecipeParserDeps):
 
             # `build/entry_points` -> `build/python/entry_points`
             self._patch_move_new_path(build_path, "/entry_points", "/python")
+            
+            # `build/force_use_keys` -> `build/variant/use_keys`
+            self._patch_move_new_path(build_path, "/force_use_keys", "/variant", "use_keys")
 
             # New `prefix_detection` section changes
             # NOTE: There is a new `force_file_type` field that may map to an unknown field that conda supports.

--- a/conda_recipe_manager/parser/recipe_parser_convert.py
+++ b/conda_recipe_manager/parser/recipe_parser_convert.py
@@ -526,7 +526,7 @@ class RecipeParserConvert(RecipeParserDeps):
 
             # `build/entry_points` -> `build/python/entry_points`
             self._patch_move_new_path(build_path, "/entry_points", "/python")
-            
+
             # `build/force_use_keys` -> `build/variant/use_keys`
             self._patch_move_new_path(build_path, "/force_use_keys", "/variant", "use_keys")
 

--- a/tests/parser/test_recipe_parser_convert.py
+++ b/tests/parser/test_recipe_parser_convert.py
@@ -180,6 +180,18 @@ def test_pre_process_recipe_text(input_file: str, expected_file: str) -> None:
             ],
             [],
         ),
+        # build/force_used_keys migration
+        (
+            "use_keys.yaml",
+            [],
+            [],
+        ),
+        # build/ignore_run_exports migration
+        (
+            "ignore_run_exports.yaml",
+            [],
+            [],
+        ),
         # Ensures that multiline summary sections that don't use | or > are converted correctly.
         (
             "non_marked_multiline_summary.yaml",

--- a/tests/test_aux_files/ignore_run_exports.yaml
+++ b/tests/test_aux_files/ignore_run_exports.yaml
@@ -1,0 +1,10 @@
+package:
+  name: test-ignore-run-exports
+  version: 1.0
+
+build:
+  number: 0
+  ignore_run_exports:
+    - python
+  ignore_run_exports_from:
+    - gcc

--- a/tests/test_aux_files/use_keys.yaml
+++ b/tests/test_aux_files/use_keys.yaml
@@ -1,0 +1,8 @@
+package:
+  name: test-use-keys
+  version: 1.0
+
+build:
+  number: 0
+  force_use_keys:
+    - mpi

--- a/tests/test_aux_files/v1_format/v1_cctools-ld64.yaml
+++ b/tests/test_aux_files/v1_format/v1_cctools-ld64.yaml
@@ -105,7 +105,8 @@ outputs:
       run:
         - llvm-lto-tapi
       ignore_run_exports:
-        - zlib
+        by_name:
+          - zlib
     about:
       license: APSL-2.0
       license_file: cctools/APPLE_LICENSE
@@ -127,7 +128,8 @@ outputs:
         - if: osx
           then: libcxx
       ignore_run_exports:
-        - zlib
+        by_name:
+          - zlib
     about:
       license: APSL-2.0
       license_file: cctools/ld64/APPLE_LICENSE

--- a/tests/test_aux_files/v1_format/v1_ignore_run_exports.yaml
+++ b/tests/test_aux_files/v1_format/v1_ignore_run_exports.yaml
@@ -1,0 +1,15 @@
+schema_version: 1
+
+package:
+  name: test-ignore-run-exports
+  version: 1.0
+
+build:
+  number: 0
+
+requirements:
+  ignore_run_exports:
+    by_name:
+      - python
+    from_package:
+      - gcc

--- a/tests/test_aux_files/v1_format/v1_use_keys.yaml
+++ b/tests/test_aux_files/v1_format/v1_use_keys.yaml
@@ -1,0 +1,11 @@
+schema_version: 1
+
+package:
+  name: test-use-keys
+  version: 1.0
+
+build:
+  number: 0
+  variant:
+    use_keys:
+      - mpi


### PR DESCRIPTION

### Description

adds a couple of conversions not yet supported:

- `build.force_use_keys` -> `build.variant.use_keys` (closes #338)
- `build.ignore_run_exports_from` -> `requirements.ignore_run_exports.from_package` (closes #298)
- `build.ignore_run_exports` -> `requirements.ignore_run_exports.by_name`
