### PR TITLE
Minor fixes for `crm graph`

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -28,7 +28,7 @@ dependencies:
   - types-requests
   - gitpython
   - networkx
-  - matplotlib
+  - matplotlib-base
   - pygraphviz
   - pre-commit
   - sphinx

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - requests
     - gitpython
     - networkx
-    - matplotlib
+    - matplotlib-base
     - pygraphviz
 
 test:


### PR DESCRIPTION
- Switches to use `matplotlib-base` over `matplotlib`. I have been told that this should reduce _some_ of the required graphics packages needed currently to run CRM in a headless environment.
- While investigating the above issue, I noticed the `crm graph` command docs did not align with the `plot` command. This fixes the interface problems.