### PR TITLE
Give warning or error when bumping recipe with current version 

### DIFF
--- a/conda_recipe_manager/commands/bump_recipe.py
+++ b/conda_recipe_manager/commands/bump_recipe.py
@@ -758,8 +758,8 @@ def bump_recipe(
     if cli_args.target_version is not None:
         if cli_args.target_version == recipe_parser.get_value(_RecipePaths.VERSION, default=None, sub_vars=True):
             log.warning(
-                "The provided target version is the same value found in the recipe file: %s", cli_args.target_version
-            )
+                "The provided target version is the same value found in the recipe file: %s", cli_args.target_version)
+            sys.exit(ExitCode.PARSE_EXCEPTION)
 
         # Version must be updated before hash to ensure the correct artifact is hashed.
         _update_version(recipe_parser, cli_args)

--- a/conda_recipe_manager/commands/bump_recipe.py
+++ b/conda_recipe_manager/commands/bump_recipe.py
@@ -747,6 +747,11 @@ def bump_recipe(
         log.error("An error occurred while parsing the recipe file contents.")
         sys.exit(ExitCode.PARSE_EXCEPTION)
 
+    if cli_args.target_version == recipe_parser.get_value(_RecipePaths.VERSION, default=None, sub_vars=True):
+        log.error(
+            "The provided target version is the same value found in the recipe file: %s", cli_args.target_version)
+        sys.exit(ExitCode.CLICK_USAGE)
+
     _post_process_cleanup(recipe_parser, cli_args)
 
     # Attempt to update fields
@@ -756,11 +761,6 @@ def bump_recipe(
     # the `build_num` flag is invalidated if we are bumping to a new version. The build number must be reset to 0 in
     # this case.
     if cli_args.target_version is not None:
-        if cli_args.target_version == recipe_parser.get_value(_RecipePaths.VERSION, default=None, sub_vars=True):
-            log.warning(
-                "The provided target version is the same value found in the recipe file: %s", cli_args.target_version)
-            sys.exit(ExitCode.PARSE_EXCEPTION)
-
         # Version must be updated before hash to ensure the correct artifact is hashed.
         _update_version(recipe_parser, cli_args)
         _update_sha256(recipe_parser, cli_args)

--- a/conda_recipe_manager/commands/bump_recipe.py
+++ b/conda_recipe_manager/commands/bump_recipe.py
@@ -748,8 +748,7 @@ def bump_recipe(
         sys.exit(ExitCode.PARSE_EXCEPTION)
 
     if cli_args.target_version == recipe_parser.get_value(_RecipePaths.VERSION, default=None, sub_vars=True):
-        log.error(
-            "The provided target version is the same value found in the recipe file: %s", cli_args.target_version)
+        log.error("The provided target version is the same value found in the recipe file: %s", cli_args.target_version)
         sys.exit(ExitCode.CLICK_USAGE)
 
     _post_process_cleanup(recipe_parser, cli_args)

--- a/conda_recipe_manager/commands/bump_recipe.py
+++ b/conda_recipe_manager/commands/bump_recipe.py
@@ -747,7 +747,9 @@ def bump_recipe(
         log.error("An error occurred while parsing the recipe file contents.")
         sys.exit(ExitCode.PARSE_EXCEPTION)
 
-    if cli_args.target_version == recipe_parser.get_value(_RecipePaths.VERSION, default=None, sub_vars=True):
+    if cli_args.target_version is not None and cli_args.target_version == recipe_parser.get_value(
+        _RecipePaths.VERSION, default=None, sub_vars=True
+    ):
         log.error("The provided target version is the same value found in the recipe file: %s", cli_args.target_version)
         sys.exit(ExitCode.CLICK_USAGE)
 

--- a/tests/commands/test_bump_recipe.py
+++ b/tests/commands/test_bump_recipe.py
@@ -192,36 +192,29 @@ def test_bump_recipe_cli(
 
 
 @pytest.mark.parametrize(
-    "recipe_file,version,expected_recipe_file",
+    "recipe_file,version",
     [
-        # ("bump_recipe/build_num_1.yaml", "0.10.8.6", "types-toml.yaml"),
-        # ("bump_recipe/build_num_1.yaml", "0.10.8.6", "types-toml.yaml"),
-        # ("bump_recipe/build_num_42.yaml", "0.10.8.6", "types-toml.yaml"),
-        # ("bump_recipe/build_num_-1.yaml", "0.10.8.6", "types-toml.yaml"),
+        ("bump_recipe/build_num_1.yaml", "0.10.8.6"),
+        ("bump_recipe/build_num_42.yaml", "0.10.8.6"),
+        ("bump_recipe/build_num_-1.yaml", "0.10.8.6"),
     ],
 )
-def test_bump_recipe_cli_with_version(
-    fs: FakeFilesystem, recipe_file: str, version: str, expected_recipe_file: str
-) -> None:
+def test_bump_recipe_cli_with_same_version(fs: FakeFilesystem, recipe_file: str, version: str) -> None:
     """
-    Test that the recipe file is successfully updated/bumped.
+    Test that the recipe can't be bumped to the same version.
+
+    :param fs: `pyfakefs` Fixture used to replace the file system
+    :param recipe_file: Target recipe file to update
+    :param version: Target version number
     """
     runner = CliRunner()
-    fs.add_real_directory(get_test_path(), read_only=False)
+    fs.add_real_directory(get_test_path(), read_only=True)
 
     recipe_file_path: Final[Path] = get_test_path() / recipe_file
-    expected_recipe_file_path: Final[Path] = get_test_path() / expected_recipe_file
-
-    cli_args: Final[list[str]] = (
-        # Only testing that target version that is already used
-        ["-t", version, str(recipe_file_path)]
-    )
 
     with patch("requests.get", new=mock_requests_get):
-        result = runner.invoke(bump_recipe.bump_recipe, cli_args)
+        result = runner.invoke(bump_recipe.bump_recipe, ["-t", version, str(recipe_file_path)])
 
-    assert recipe_file_path != expected_recipe_file_path
-    assert load_file(recipe_file_path) == load_file(expected_recipe_file_path)
     # testing that it exits with the correct error code
     assert result.exit_code == ExitCode.CLICK_USAGE
 

--- a/tests/commands/test_bump_recipe.py
+++ b/tests/commands/test_bump_recipe.py
@@ -211,14 +211,14 @@ def test_bump_recipe_cli_with_same_version(
     :param fs: `pyfakefs` Fixture used to replace the file system
     :param recipe_file: Target recipe file to update
     :param version: Target version number
-    :param user_override_flag: provides the `--override-build-num` flag
+    :param user_override_flag: Provides the `--override-build-num` flag
     """
     runner = CliRunner()
     fs.add_real_directory(get_test_path(), read_only=True)
 
     recipe_file_path: Final[Path] = get_test_path() / recipe_file
 
-    # setting a flag depending on weather it's true or false.
+    # Setting a flag depending on weather it's true or false.
     cli_args: Final[list[str]] = (
         ["--override-build-num", "100", "-t", version, str(recipe_file_path)]
         if user_override_flag
@@ -228,7 +228,7 @@ def test_bump_recipe_cli_with_same_version(
     with patch("requests.get", new=mock_requests_get):
         result = runner.invoke(bump_recipe.bump_recipe, cli_args)
 
-    # testing that it exits with the correct error code
+    # Testing that it exits with the correct error code
     assert result.exit_code == ExitCode.CLICK_USAGE
 
 

--- a/tests/commands/test_bump_recipe.py
+++ b/tests/commands/test_bump_recipe.py
@@ -235,7 +235,6 @@ def test_bump_recipe_cli_with_same_version(
 @pytest.mark.parametrize(
     "recipe_file,version,build_num,expected_recipe_file",
     [
-        # "0.10.8.20240310", "bump_recipe/types-toml_version_bump.yaml
         ("types-toml.yaml", "0.10.8.20240310", "100", "bump_recipe/build_num_100_bumped.yaml"),
         ("types-toml.yaml", "0.10.8.20240310", "42", "bump_recipe//build_num_42_bumped.yaml"),
         ("types-toml.yaml", "0.10.8.20240310", "0", "bump_recipe/build_num_0_bumped.yaml"),

--- a/tests/commands/test_bump_recipe.py
+++ b/tests/commands/test_bump_recipe.py
@@ -123,11 +123,11 @@ def test_usage() -> None:
         # NOTE: These have no source section, therefore all SHA-256 update attempts (and associated network requests)
         # should be skipped.
         ("bump_recipe/build_num_1.yaml", None, "bump_recipe/build_num_2.yaml"),
-        # ("bump_recipe/build_num_1.yaml", "0.10.8.6", "simple-recipe.yaml"),
+        ("bump_recipe/build_num_1.yaml", "0.10.8.20240310", "bump_recipe/types-toml_version_bump.yaml"),
         ("bump_recipe/build_num_42.yaml", None, "bump_recipe/build_num_43.yaml"),
-        # ("bump_recipe/build_num_42.yaml", "0.10.8.6", "simple-recipe.yaml"),
-        ("bump_recipe/build_num_-1.yaml", None, "simple-recipe.yaml"),
-        # ("bump_recipe/build_num_-1.yaml", "0.10.8.6", "simple-recipe.yaml"),
+        ("bump_recipe/build_num_42.yaml", "0.10.8.20240310", "bump_recipe/types-toml_version_bump.yaml"),
+        ("bump_recipe/build_num_-1.yaml", None, "bump_recipe/build_num_0.yaml"),
+        ("bump_recipe/build_num_-1.yaml", "0.10.8.20240310", "bump_recipe/types-toml_version_bump.yaml"),
         ## Attempt to correct URLs using the PyPi API ##
         # "Standard" Grayskull-based recipe needing a URL correction.
         ("bump_recipe/types-toml_fix_pypi_url.yaml", "0.10.8.20240310", "bump_recipe/types-toml_version_bump.yaml"),
@@ -192,39 +192,53 @@ def test_bump_recipe_cli(
 
 
 @pytest.mark.parametrize(
-    "recipe_file,version",
+    "recipe_file,version,user_override_flag",
     [
-        ("bump_recipe/build_num_1.yaml", "0.10.8.6"),
-        ("bump_recipe/build_num_42.yaml", "0.10.8.6"),
-        ("bump_recipe/build_num_-1.yaml", "0.10.8.6"),
+        ("bump_recipe/build_num_1.yaml", "0.10.8.6", False),
+        ("bump_recipe/build_num_42.yaml", "0.10.8.6", False),
+        ("bump_recipe/build_num_-1.yaml", "0.10.8.6", False),
+        ("bump_recipe/build_num_1.yaml", "0.10.8.6", True),
+        ("bump_recipe/build_num_42.yaml", "0.10.8.6", True),
+        ("bump_recipe/build_num_-1.yaml", "0.10.8.6", True),
     ],
 )
-def test_bump_recipe_cli_with_same_version(fs: FakeFilesystem, recipe_file: str, version: str) -> None:
+def test_bump_recipe_cli_with_same_version(
+    fs: FakeFilesystem, recipe_file: str, version: str, user_override_flag: bool
+) -> None:
     """
     Test that the recipe can't be bumped to the same version.
 
     :param fs: `pyfakefs` Fixture used to replace the file system
     :param recipe_file: Target recipe file to update
     :param version: Target version number
+    :param user_override_flag: provides the `--override-build-num` flag
     """
     runner = CliRunner()
     fs.add_real_directory(get_test_path(), read_only=True)
 
     recipe_file_path: Final[Path] = get_test_path() / recipe_file
 
+    # setting a flag depending on weather it's true or false.
+    cli_args: Final[list[str]] = (
+        ["--override-build-num", "100", "-t", version, str(recipe_file_path)]
+        if user_override_flag
+        else ["-t", version, str(recipe_file_path)]
+    )
+
     with patch("requests.get", new=mock_requests_get):
-        result = runner.invoke(bump_recipe.bump_recipe, ["-t", version, str(recipe_file_path)])
+        result = runner.invoke(bump_recipe.bump_recipe, cli_args)
 
     # testing that it exits with the correct error code
     assert result.exit_code == ExitCode.CLICK_USAGE
 
 
 @pytest.mark.parametrize(
-    "recipe_file, version, build_num, expected_recipe_file",
+    "recipe_file,version,build_num,expected_recipe_file",
     [
-        ("simple-recipe.yaml", "0.10.8.6", "100", "bump_recipe/build_num_100.yaml"),
-        ("simple-recipe.yaml", "0.10.8.6", "42", "bump_recipe/build_num_42.yaml"),
-        ("simple-recipe.yaml", "0.10.8.6", "0", "bump_recipe/build_num_0.yaml"),
+        # "0.10.8.20240310", "bump_recipe/types-toml_version_bump.yaml
+        ("types-toml.yaml", "0.10.8.20240310", "100", "bump_recipe/build_num_100_bumped.yaml"),
+        ("types-toml.yaml", "0.10.8.20240310", "42", "bump_recipe//build_num_42_bumped.yaml"),
+        ("types-toml.yaml", "0.10.8.20240310", "0", "bump_recipe/build_num_0_bumped.yaml"),
     ],
 )
 def test_bump_recipe_override_build_num(

--- a/tests/test_aux_files/bump_recipe/build_num_-1.yaml
+++ b/tests/test_aux_files/bump_recipe/build_num_-1.yaml
@@ -1,53 +1,51 @@
-{% set zz_non_alpha_first = 42 %}
 {% set name = "types-toml" %}
 {% set version = "0.10.8.6" %}
 
 package:
-  name: {{ name|lower }}  # [unix]
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/types-toml-{{ version }}.tar.gz
+  sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
 
 build:
   number: -1
   skip: true  # [py<37]
-  is_true: true
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
-# Comment above a top-level structure
 requirements:
-  empty_field1:
   host:
-    - setuptools  # [unix]
-    - fakereq  # [unix] selector with comment
-  empty_field2:  # [unix and win] # selector with comment with comment symbol
+    - setuptools
+    - wheel
+    - pip
+    - python
   run:
-    - python  # not a selector
-  empty_field3:
+    - python
+
+test:
+  imports:
+    - types
+  requires:
+    - pip
+  commands:
+    - pip check
+    - test -f $SP_DIR/toml-stubs/__init__.pyi  # [unix]
 
 about:
-  summary: This is a small recipe for testing
+  home: https://github.com/python/typeshed
+  summary: Typing stubs for toml
   description: |
-    This is a PEP '561 type stub package for the toml package.
+    This is a PEP 561 type stub package for the toml package.
     It can be used by type-checking tools like mypy, pyright,
     pytype, PyCharm, etc. to check code that uses toml.
   license: Apache-2.0 AND MIT
+  license_file: LICENSE
+  license_family: OTHER
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://pypi.org/project/types-toml/
 
-multi_level:
-  list_1:
-    - foo
-    # Ensure a comment in a list is supported
-    - bar
-  list_2:
-    - cat
-    - bat
-    - mat
-  list_3:
-    - ls
-    - sl
-    - cowsay
-
-test_var_usage:
-  foo: {{ version }}
-  bar:
-    - baz
-    - {{ zz_non_alpha_first }}
-    - blah
-    - This {{ name }} is silly
-    - last
+extra:
+  recipe-maintainers:
+    - fhoehle
+    - conda-forge/mypy

--- a/tests/test_aux_files/bump_recipe/build_num_0.yaml
+++ b/tests/test_aux_files/bump_recipe/build_num_0.yaml
@@ -1,53 +1,51 @@
-{% set zz_non_alpha_first = 42 %}
 {% set name = "types-toml" %}
 {% set version = "0.10.8.6" %}
 
 package:
-  name: {{ name|lower }}  # [unix]
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/types-toml-{{ version }}.tar.gz
+  sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
 
 build:
   number: 0
   skip: true  # [py<37]
-  is_true: true
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
-# Comment above a top-level structure
 requirements:
-  empty_field1:
   host:
-    - setuptools  # [unix]
-    - fakereq  # [unix] selector with comment
-  empty_field2:  # [unix and win] # selector with comment with comment symbol
+    - setuptools
+    - wheel
+    - pip
+    - python
   run:
-    - python  # not a selector
-  empty_field3:
+    - python
+
+test:
+  imports:
+    - types
+  requires:
+    - pip
+  commands:
+    - pip check
+    - test -f $SP_DIR/toml-stubs/__init__.pyi  # [unix]
 
 about:
-  summary: This is a small recipe for testing
+  home: https://github.com/python/typeshed
+  summary: Typing stubs for toml
   description: |
-    This is a PEP '561 type stub package for the toml package.
+    This is a PEP 561 type stub package for the toml package.
     It can be used by type-checking tools like mypy, pyright,
     pytype, PyCharm, etc. to check code that uses toml.
   license: Apache-2.0 AND MIT
+  license_file: LICENSE
+  license_family: OTHER
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://pypi.org/project/types-toml/
 
-multi_level:
-  list_1:
-    - foo
-    # Ensure a comment in a list is supported
-    - bar
-  list_2:
-    - cat
-    - bat
-    - mat
-  list_3:
-    - ls
-    - sl
-    - cowsay
-
-test_var_usage:
-  foo: {{ version }}
-  bar:
-    - baz
-    - {{ zz_non_alpha_first }}
-    - blah
-    - This {{ name }} is silly
-    - last
+extra:
+  recipe-maintainers:
+    - fhoehle
+    - conda-forge/mypy

--- a/tests/test_aux_files/bump_recipe/build_num_0_bumped.yaml
+++ b/tests/test_aux_files/bump_recipe/build_num_0_bumped.yaml
@@ -1,0 +1,51 @@
+{% set name = "types-toml" %}
+{% set version = "0.10.8.20240310" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/types-toml-{{ version }}.tar.gz
+  sha256: e594f5bc141acabe4b0298d05234e80195116667edad3d6a9cd610cab36bc4e1
+
+build:
+  number: 0
+  skip: true  # [py<37]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - setuptools
+    - wheel
+    - pip
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - types
+  requires:
+    - pip
+  commands:
+    - pip check
+    - test -f $SP_DIR/toml-stubs/__init__.pyi  # [unix]
+
+about:
+  home: https://github.com/python/typeshed
+  summary: Typing stubs for toml
+  description: |
+    This is a PEP 561 type stub package for the toml package.
+    It can be used by type-checking tools like mypy, pyright,
+    pytype, PyCharm, etc. to check code that uses toml.
+  license: Apache-2.0 AND MIT
+  license_file: LICENSE
+  license_family: OTHER
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://pypi.org/project/types-toml/
+
+extra:
+  recipe-maintainers:
+    - fhoehle
+    - conda-forge/mypy

--- a/tests/test_aux_files/bump_recipe/build_num_1.yaml
+++ b/tests/test_aux_files/bump_recipe/build_num_1.yaml
@@ -1,53 +1,51 @@
-{% set zz_non_alpha_first = 42 %}
 {% set name = "types-toml" %}
 {% set version = "0.10.8.6" %}
 
 package:
-  name: {{ name|lower }}  # [unix]
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/types-toml-{{ version }}.tar.gz
+  sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
 
 build:
   number: 1
   skip: true  # [py<37]
-  is_true: true
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
-# Comment above a top-level structure
 requirements:
-  empty_field1:
   host:
-    - setuptools  # [unix]
-    - fakereq  # [unix] selector with comment
-  empty_field2:  # [unix and win] # selector with comment with comment symbol
+    - setuptools
+    - wheel
+    - pip
+    - python
   run:
-    - python  # not a selector
-  empty_field3:
+    - python
+
+test:
+  imports:
+    - types
+  requires:
+    - pip
+  commands:
+    - pip check
+    - test -f $SP_DIR/toml-stubs/__init__.pyi  # [unix]
 
 about:
-  summary: This is a small recipe for testing
+  home: https://github.com/python/typeshed
+  summary: Typing stubs for toml
   description: |
-    This is a PEP '561 type stub package for the toml package.
+    This is a PEP 561 type stub package for the toml package.
     It can be used by type-checking tools like mypy, pyright,
     pytype, PyCharm, etc. to check code that uses toml.
   license: Apache-2.0 AND MIT
+  license_file: LICENSE
+  license_family: OTHER
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://pypi.org/project/types-toml/
 
-multi_level:
-  list_1:
-    - foo
-    # Ensure a comment in a list is supported
-    - bar
-  list_2:
-    - cat
-    - bat
-    - mat
-  list_3:
-    - ls
-    - sl
-    - cowsay
-
-test_var_usage:
-  foo: {{ version }}
-  bar:
-    - baz
-    - {{ zz_non_alpha_first }}
-    - blah
-    - This {{ name }} is silly
-    - last
+extra:
+  recipe-maintainers:
+    - fhoehle
+    - conda-forge/mypy

--- a/tests/test_aux_files/bump_recipe/build_num_100.yaml
+++ b/tests/test_aux_files/bump_recipe/build_num_100.yaml
@@ -1,53 +1,51 @@
-{% set zz_non_alpha_first = 42 %}
 {% set name = "types-toml" %}
 {% set version = "0.10.8.6" %}
 
 package:
-  name: {{ name|lower }}  # [unix]
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/types-toml-{{ version }}.tar.gz
+  sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
 
 build:
   number: 100
   skip: true  # [py<37]
-  is_true: true
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
-# Comment above a top-level structure
 requirements:
-  empty_field1:
   host:
-    - setuptools  # [unix]
-    - fakereq  # [unix] selector with comment
-  empty_field2:  # [unix and win] # selector with comment with comment symbol
+    - setuptools
+    - wheel
+    - pip
+    - python
   run:
-    - python  # not a selector
-  empty_field3:
+    - python
+
+test:
+  imports:
+    - types
+  requires:
+    - pip
+  commands:
+    - pip check
+    - test -f $SP_DIR/toml-stubs/__init__.pyi  # [unix]
 
 about:
-  summary: This is a small recipe for testing
+  home: https://github.com/python/typeshed
+  summary: Typing stubs for toml
   description: |
-    This is a PEP '561 type stub package for the toml package.
+    This is a PEP 561 type stub package for the toml package.
     It can be used by type-checking tools like mypy, pyright,
     pytype, PyCharm, etc. to check code that uses toml.
   license: Apache-2.0 AND MIT
+  license_file: LICENSE
+  license_family: OTHER
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://pypi.org/project/types-toml/
 
-multi_level:
-  list_1:
-    - foo
-    # Ensure a comment in a list is supported
-    - bar
-  list_2:
-    - cat
-    - bat
-    - mat
-  list_3:
-    - ls
-    - sl
-    - cowsay
-
-test_var_usage:
-  foo: {{ version }}
-  bar:
-    - baz
-    - {{ zz_non_alpha_first }}
-    - blah
-    - This {{ name }} is silly
-    - last
+extra:
+  recipe-maintainers:
+    - fhoehle
+    - conda-forge/mypy

--- a/tests/test_aux_files/bump_recipe/build_num_100_bumped.yaml
+++ b/tests/test_aux_files/bump_recipe/build_num_100_bumped.yaml
@@ -1,0 +1,51 @@
+{% set name = "types-toml" %}
+{% set version = "0.10.8.20240310" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/types-toml-{{ version }}.tar.gz
+  sha256: e594f5bc141acabe4b0298d05234e80195116667edad3d6a9cd610cab36bc4e1
+
+build:
+  number: 100
+  skip: true  # [py<37]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - setuptools
+    - wheel
+    - pip
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - types
+  requires:
+    - pip
+  commands:
+    - pip check
+    - test -f $SP_DIR/toml-stubs/__init__.pyi  # [unix]
+
+about:
+  home: https://github.com/python/typeshed
+  summary: Typing stubs for toml
+  description: |
+    This is a PEP 561 type stub package for the toml package.
+    It can be used by type-checking tools like mypy, pyright,
+    pytype, PyCharm, etc. to check code that uses toml.
+  license: Apache-2.0 AND MIT
+  license_file: LICENSE
+  license_family: OTHER
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://pypi.org/project/types-toml/
+
+extra:
+  recipe-maintainers:
+    - fhoehle
+    - conda-forge/mypy

--- a/tests/test_aux_files/bump_recipe/build_num_2.yaml
+++ b/tests/test_aux_files/bump_recipe/build_num_2.yaml
@@ -1,53 +1,51 @@
-{% set zz_non_alpha_first = 42 %}
 {% set name = "types-toml" %}
 {% set version = "0.10.8.6" %}
 
 package:
-  name: {{ name|lower }}  # [unix]
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/types-toml-{{ version }}.tar.gz
+  sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
 
 build:
   number: 2
   skip: true  # [py<37]
-  is_true: true
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
-# Comment above a top-level structure
 requirements:
-  empty_field1:
   host:
-    - setuptools  # [unix]
-    - fakereq  # [unix] selector with comment
-  empty_field2:  # [unix and win] # selector with comment with comment symbol
+    - setuptools
+    - wheel
+    - pip
+    - python
   run:
-    - python  # not a selector
-  empty_field3:
+    - python
+
+test:
+  imports:
+    - types
+  requires:
+    - pip
+  commands:
+    - pip check
+    - test -f $SP_DIR/toml-stubs/__init__.pyi  # [unix]
 
 about:
-  summary: This is a small recipe for testing
+  home: https://github.com/python/typeshed
+  summary: Typing stubs for toml
   description: |
-    This is a PEP '561 type stub package for the toml package.
+    This is a PEP 561 type stub package for the toml package.
     It can be used by type-checking tools like mypy, pyright,
     pytype, PyCharm, etc. to check code that uses toml.
   license: Apache-2.0 AND MIT
+  license_file: LICENSE
+  license_family: OTHER
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://pypi.org/project/types-toml/
 
-multi_level:
-  list_1:
-    - foo
-    # Ensure a comment in a list is supported
-    - bar
-  list_2:
-    - cat
-    - bat
-    - mat
-  list_3:
-    - ls
-    - sl
-    - cowsay
-
-test_var_usage:
-  foo: {{ version }}
-  bar:
-    - baz
-    - {{ zz_non_alpha_first }}
-    - blah
-    - This {{ name }} is silly
-    - last
+extra:
+  recipe-maintainers:
+    - fhoehle
+    - conda-forge/mypy

--- a/tests/test_aux_files/bump_recipe/build_num_2.yaml
+++ b/tests/test_aux_files/bump_recipe/build_num_2.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/types-toml-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/types-toml-{{ version }}.tar.gz
   sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
 
 build:

--- a/tests/test_aux_files/bump_recipe/build_num_42.yaml
+++ b/tests/test_aux_files/bump_recipe/build_num_42.yaml
@@ -1,53 +1,51 @@
-{% set zz_non_alpha_first = 42 %}
 {% set name = "types-toml" %}
 {% set version = "0.10.8.6" %}
 
 package:
-  name: {{ name|lower }}  # [unix]
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/types-toml-{{ version }}.tar.gz
+  sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
 
 build:
   number: 42
   skip: true  # [py<37]
-  is_true: true
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
-# Comment above a top-level structure
 requirements:
-  empty_field1:
   host:
-    - setuptools  # [unix]
-    - fakereq  # [unix] selector with comment
-  empty_field2:  # [unix and win] # selector with comment with comment symbol
+    - setuptools
+    - wheel
+    - pip
+    - python
   run:
-    - python  # not a selector
-  empty_field3:
+    - python
+
+test:
+  imports:
+    - types
+  requires:
+    - pip
+  commands:
+    - pip check
+    - test -f $SP_DIR/toml-stubs/__init__.pyi  # [unix]
 
 about:
-  summary: This is a small recipe for testing
+  home: https://github.com/python/typeshed
+  summary: Typing stubs for toml
   description: |
-    This is a PEP '561 type stub package for the toml package.
+    This is a PEP 561 type stub package for the toml package.
     It can be used by type-checking tools like mypy, pyright,
     pytype, PyCharm, etc. to check code that uses toml.
   license: Apache-2.0 AND MIT
+  license_file: LICENSE
+  license_family: OTHER
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://pypi.org/project/types-toml/
 
-multi_level:
-  list_1:
-    - foo
-    # Ensure a comment in a list is supported
-    - bar
-  list_2:
-    - cat
-    - bat
-    - mat
-  list_3:
-    - ls
-    - sl
-    - cowsay
-
-test_var_usage:
-  foo: {{ version }}
-  bar:
-    - baz
-    - {{ zz_non_alpha_first }}
-    - blah
-    - This {{ name }} is silly
-    - last
+extra:
+  recipe-maintainers:
+    - fhoehle
+    - conda-forge/mypy

--- a/tests/test_aux_files/bump_recipe/build_num_42_bumped.yaml
+++ b/tests/test_aux_files/bump_recipe/build_num_42_bumped.yaml
@@ -1,0 +1,51 @@
+{% set name = "types-toml" %}
+{% set version = "0.10.8.20240310" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/types-toml-{{ version }}.tar.gz
+  sha256: e594f5bc141acabe4b0298d05234e80195116667edad3d6a9cd610cab36bc4e1
+
+build:
+  number: 42
+  skip: true  # [py<37]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - setuptools
+    - wheel
+    - pip
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - types
+  requires:
+    - pip
+  commands:
+    - pip check
+    - test -f $SP_DIR/toml-stubs/__init__.pyi  # [unix]
+
+about:
+  home: https://github.com/python/typeshed
+  summary: Typing stubs for toml
+  description: |
+    This is a PEP 561 type stub package for the toml package.
+    It can be used by type-checking tools like mypy, pyright,
+    pytype, PyCharm, etc. to check code that uses toml.
+  license: Apache-2.0 AND MIT
+  license_file: LICENSE
+  license_family: OTHER
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://pypi.org/project/types-toml/
+
+extra:
+  recipe-maintainers:
+    - fhoehle
+    - conda-forge/mypy

--- a/tests/test_aux_files/bump_recipe/build_num_43.yaml
+++ b/tests/test_aux_files/bump_recipe/build_num_43.yaml
@@ -1,53 +1,51 @@
-{% set zz_non_alpha_first = 42 %}
 {% set name = "types-toml" %}
 {% set version = "0.10.8.6" %}
 
 package:
-  name: {{ name|lower }}  # [unix]
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/types-toml-{{ version }}.tar.gz
+  sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
 
 build:
   number: 43
   skip: true  # [py<37]
-  is_true: true
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
-# Comment above a top-level structure
 requirements:
-  empty_field1:
   host:
-    - setuptools  # [unix]
-    - fakereq  # [unix] selector with comment
-  empty_field2:  # [unix and win] # selector with comment with comment symbol
+    - setuptools
+    - wheel
+    - pip
+    - python
   run:
-    - python  # not a selector
-  empty_field3:
+    - python
+
+test:
+  imports:
+    - types
+  requires:
+    - pip
+  commands:
+    - pip check
+    - test -f $SP_DIR/toml-stubs/__init__.pyi  # [unix]
 
 about:
-  summary: This is a small recipe for testing
+  home: https://github.com/python/typeshed
+  summary: Typing stubs for toml
   description: |
-    This is a PEP '561 type stub package for the toml package.
+    This is a PEP 561 type stub package for the toml package.
     It can be used by type-checking tools like mypy, pyright,
     pytype, PyCharm, etc. to check code that uses toml.
   license: Apache-2.0 AND MIT
+  license_file: LICENSE
+  license_family: OTHER
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://pypi.org/project/types-toml/
 
-multi_level:
-  list_1:
-    - foo
-    # Ensure a comment in a list is supported
-    - bar
-  list_2:
-    - cat
-    - bat
-    - mat
-  list_3:
-    - ls
-    - sl
-    - cowsay
-
-test_var_usage:
-  foo: {{ version }}
-  bar:
-    - baz
-    - {{ zz_non_alpha_first }}
-    - blah
-    - This {{ name }} is silly
-    - last
+extra:
+  recipe-maintainers:
+    - fhoehle
+    - conda-forge/mypy


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Resolves: https://github.com/conda/conda-recipe-manager/issues/347

Modified the tool to exit with an error when the target version matches the current version in the recipe, preventing unnecessary changes or accidental resets of the build number to 0. The change is implemented in the `bump_recipe` function where we check the versions.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-recipe-manager/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-recipe-manager/blob/main/CONTRIBUTING.md -->
