### PR TITLE
Fixes JINJA rendering issue in V0 recipes

### DIFF
--- a/.github/workflows/commit_checks.yaml
+++ b/.github/workflows/commit_checks.yaml
@@ -47,8 +47,9 @@ jobs:
             source $CONDA/bin/activate
             conda create --name build-env -y python=3.11 conda-build
             conda activate build-env
-            conda build -c defaults -c conda-forge recipe/meta.yaml
+            conda build -c defaults recipe/meta.yaml
   # Eat our own dog food and build this project with rattler-build by converting our existing recipe.
+  # Remember, `rattler-build` will pull from the `conda-forge` channel, which may cause some version inconsistencies.
   build-recipe-rattler:
       runs-on: ubuntu-latest
       steps:

--- a/conda_recipe_manager/parser/recipe_reader.py
+++ b/conda_recipe_manager/parser/recipe_reader.py
@@ -414,12 +414,12 @@ class RecipeReader(IsModifiable):
                 if replace_match:
                     value = value.replace(replace_match.group(2), replace_match.group(3))
                 s = s.replace(match, value)
-            # $-Escaping the unresolved variable does a few things:
-            #   - Clearly identifies the value as an unresolved variable
-            #   - Normalizes the substitution syntax with V1
-            #   - Ensures the returned value is YAML-parsable
-            elif self._schema_version == SchemaVersion.V0 and s[:2] == "{{":
-                s = f"${s}"
+
+        # If there is leading V0 (unescaped) JINJA that was not able to be fully rendered, it will not be able to be
+        # parsed by PyYaml. So it is best to just return the value as a string, without evaluating the type (which, to
+        # be clear, should be a string).
+        if self._schema_version == SchemaVersion.V0 and s[:2] == "{{":
+            return s
         return cast(JsonType, yaml.load(s, Loader=SafeLoader))
 
     def _init_vars_tbl(self) -> None:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,9 @@ requirements:
     - wheel
   run:
     - python >=3.11
-    - click >=8.1.7
+    # Version 8.2.0 introduces breaking changes around the `CliRunner` class, which breaks our
+    # automated tests. We can allow for this version when it becomes available on `defaults`.
+    - click <8.2.0
     - conda
     - jinja2
     - pyyaml

--- a/tests/parser/test_recipe_parser_convert.py
+++ b/tests/parser/test_recipe_parser_convert.py
@@ -88,38 +88,38 @@ def test_pre_process_recipe_text(input_file: str, expected_file: str) -> None:
             [],
             [
                 "Recipe upgrades cannot currently upgrade ambiguous version constraints on "
-                "dependencies that use variables: ${{ compiler('c') }}",
+                "dependencies that use variables: {{ compiler('c') }}",
                 "Recipe upgrades cannot currently upgrade ambiguous version constraints on "
-                "dependencies that use variables: ${{ compiler('cxx') }}",
+                "dependencies that use variables: {{ compiler('cxx') }}",
                 "Recipe upgrades cannot currently upgrade ambiguous version constraints on "
-                "dependencies that use variables: ${{ compiler('c') }}",
+                "dependencies that use variables: {{ compiler('c') }}",
                 "Recipe upgrades cannot currently upgrade ambiguous version constraints on "
-                "dependencies that use variables: ${{ compiler('cxx') }}",
+                "dependencies that use variables: {{ compiler('cxx') }}",
                 "Recipe upgrades cannot currently upgrade ambiguous version constraints on "
-                "dependencies that use variables: ${{ compiler('c') }}",
+                "dependencies that use variables: {{ compiler('c') }}",
                 "Recipe upgrades cannot currently upgrade ambiguous version constraints on "
-                "dependencies that use variables: ${{ compiler('cxx') }}",
+                "dependencies that use variables: {{ compiler('cxx') }}",
                 "Recipe upgrades cannot currently upgrade ambiguous version constraints on "
-                "dependencies that use variables: ${{ compiler('c') }}",
+                "dependencies that use variables: {{ compiler('c') }}",
                 "Recipe upgrades cannot currently upgrade ambiguous version constraints on "
-                "dependencies that use variables: ${{ compiler('cxx') }}",
+                "dependencies that use variables: {{ compiler('cxx') }}",
                 "Recipe upgrades cannot currently upgrade ambiguous version constraints on "
-                'dependencies that use variables: ${{ pin_subpackage("libgoogle-cloud-all", '
+                'dependencies that use variables: {{ pin_subpackage("libgoogle-cloud-all", '
                 "exact=True) }}",
                 "Recipe upgrades cannot currently upgrade ambiguous version constraints on "
-                "dependencies that use variables: ${{ compiler('c') }}",
+                "dependencies that use variables: {{ compiler('c') }}",
                 "Recipe upgrades cannot currently upgrade ambiguous version constraints on "
-                "dependencies that use variables: ${{ compiler('cxx') }}",
+                "dependencies that use variables: {{ compiler('cxx') }}",
                 "Recipe upgrades cannot currently upgrade ambiguous version constraints on "
-                "dependencies that use variables: ${{ "
+                "dependencies that use variables: {{ "
                 'pin_subpackage("libgoogle-cloud-all-devel", exact=True) }}',
                 "Recipe upgrades cannot currently upgrade ambiguous version constraints on "
-                "dependencies that use variables: ${{ "
+                "dependencies that use variables: {{ "
                 'pin_subpackage("libgoogle-cloud-all-devel", exact=True) }}',
                 "Recipe upgrades cannot currently upgrade ambiguous version constraints on "
-                "dependencies that use variables: ${{ compiler('c') }}",
+                "dependencies that use variables: {{ compiler('c') }}",
                 "Recipe upgrades cannot currently upgrade ambiguous version constraints on "
-                "dependencies that use variables: ${{ compiler('cxx') }}",
+                "dependencies that use variables: {{ compiler('cxx') }}",
                 "A non-list item had a selector at: /outputs/0/script",
                 "A non-list item had a selector at: /outputs/1/script",
                 "A non-list item had a selector at: /outputs/0/script",
@@ -163,7 +163,7 @@ def test_pre_process_recipe_text(input_file: str, expected_file: str) -> None:
             [
                 (
                     "Recipe upgrades cannot currently upgrade ambiguous version constraints on dependencies that"
-                    ' use variables: ${{ pin_subpackage("libnvpl-fft" ~ somajor ) }}'
+                    ' use variables: {{ pin_subpackage("libnvpl-fft" ~ somajor ) }}'
                 ),
                 "The following key(s) contain unsupported syntax: soversion",
                 "No `license` provided in `/about`",
@@ -224,7 +224,7 @@ def test_pre_process_recipe_text(input_file: str, expected_file: str) -> None:
             [
                 (
                     "Recipe upgrades cannot currently upgrade ambiguous version constraints on dependencies that"
-                    " use variables: ${{ compiler('rust') }} >=1.65.0"
+                    " use variables: {{ compiler('rust') }} >=1.65.0"
                 ),
                 "Could not patch unrecognized license: `Apache-2.0 AND MIT`",
                 "Field at `/about/license_family` is no longer supported.",
@@ -257,11 +257,11 @@ def test_pre_process_recipe_text(input_file: str, expected_file: str) -> None:
             [],
             [
                 "Recipe upgrades cannot currently upgrade ambiguous version constraints on dependencies that"
-                " use variables: ${{ stdlib('c') }}",
+                " use variables: {{ stdlib('c') }}",
                 "Recipe upgrades cannot currently upgrade ambiguous version constraints on dependencies that"
-                " use variables: ${{ compiler('c') }}",
+                " use variables: {{ compiler('c') }}",
                 "Recipe upgrades cannot currently upgrade ambiguous version constraints on dependencies that"
-                " use variables: ${{ compiler('cxx') }}",
+                " use variables: {{ compiler('cxx') }}",
                 "Field at `/about/license_family` is no longer supported.",
             ],
         ),

--- a/tests/parser/test_recipe_reader.py
+++ b/tests/parser/test_recipe_reader.py
@@ -652,8 +652,8 @@ def test_contains_value(file: str, path: str, expected: bool) -> None:
         ("sub_vars.yaml", "/requirements/fake_run_constrained/20", True, "types_toml"),
         ("sub_vars.yaml", "/requirements/fake_run_constrained/21", True, "TYPES_TOML"),
         # Complex split and join cases. Note that we do not replace if split/join would result in a non-string value.
-        ("sub_vars.yaml", "/requirements/fake_run_constrained/22", True, "${{ name.split('-') }}"),
-        ("sub_vars.yaml", "/requirements/fake_run_constrained/23", True, "${{ '.'.join(name) }}"),
+        ("sub_vars.yaml", "/requirements/fake_run_constrained/22", True, "{{ name.split('-') }}"),
+        ("sub_vars.yaml", "/requirements/fake_run_constrained/23", True, "{{ '.'.join(name) }}"),
         ("sub_vars.yaml", "/requirements/fake_run_constrained/24", True, "TYPES.toml"),
         ("sub_vars.yaml", "/requirements/fake_run_constrained/25", True, "TYPES"),
         ("sub_vars.yaml", "/requirements/fake_run_constrained/26", True, "TYPES.toml"),

--- a/tests/parser/test_recipe_reader_deps.py
+++ b/tests/parser/test_recipe_reader_deps.py
@@ -274,14 +274,14 @@ def test_get_package_names_to_path(file: str, expected: dict[str, str]) -> None:
                         "libprotobuf",
                         "/outputs/0/requirements/build/0",
                         DependencySection.BUILD,
-                        DependencyVariable("${{ compiler('c') }}"),
+                        DependencyVariable("{{ compiler('c') }}"),
                         selector=None,
                     ),
                     Dependency(
                         "libprotobuf",
                         "/outputs/0/requirements/build/1",
                         DependencySection.BUILD,
-                        DependencyVariable("${{ compiler('cxx') }}"),
+                        DependencyVariable("{{ compiler('cxx') }}"),
                         selector=None,
                     ),
                     Dependency(
@@ -381,14 +381,14 @@ def test_get_package_names_to_path(file: str, expected: dict[str, str]) -> None:
                         "libprotobuf-static",
                         "/outputs/1/requirements/build/0",
                         DependencySection.BUILD,
-                        DependencyVariable("${{ compiler('c') }}"),
+                        DependencyVariable("{{ compiler('c') }}"),
                         selector=None,
                     ),
                     Dependency(
                         "libprotobuf-static",
                         "/outputs/1/requirements/build/1",
                         DependencySection.BUILD,
-                        DependencyVariable("${{ compiler('cxx') }}"),
+                        DependencyVariable("{{ compiler('cxx') }}"),
                         selector=None,
                     ),
                     Dependency(
@@ -458,7 +458,7 @@ def test_get_package_names_to_path(file: str, expected: dict[str, str]) -> None:
                         "libprotobuf-static",
                         "/outputs/1/requirements/host/1",
                         DependencySection.HOST,
-                        DependencyVariable("${{ pin_subpackage('libprotobuf', exact=True) }}"),
+                        DependencyVariable("{{ pin_subpackage('libprotobuf', exact=True) }}"),
                         SelectorParser("[not win]", SchemaVersion.V0),
                     ),
                     Dependency(
@@ -472,7 +472,7 @@ def test_get_package_names_to_path(file: str, expected: dict[str, str]) -> None:
                         "libprotobuf-static",
                         "/outputs/1/requirements/run/1",
                         DependencySection.RUN,
-                        DependencyVariable("${{ pin_subpackage('libprotobuf', exact=True) }}"),
+                        DependencyVariable("{{ pin_subpackage('libprotobuf', exact=True) }}"),
                         SelectorParser("[not win]", SchemaVersion.V0),
                     ),
                     Dependency(


### PR DESCRIPTION
- This fixes an issue with `RecipeReader::get_value(..., sub_vars=True)` where V0 recipes would use the V1 escape syntax to get around some type evaluation issues.
- Now unrendered V0 variables will be properly returned as unescaped JINJA statements.
