### PR TITLE
384 comments above the variables section get moved to after in V0

### DIFF
--- a/conda_recipe_manager/parser/_node.py
+++ b/conda_recipe_manager/parser/_node.py
@@ -4,11 +4,23 @@
 
 from __future__ import annotations
 
+from enum import Enum, auto
 from typing import Optional
 
 from conda_recipe_manager.parser._types import ROOT_NODE_VALUE
 from conda_recipe_manager.parser.types import MultilineVariant, NodeValue
 from conda_recipe_manager.types import SentinelType
+
+
+class CommentPosition(Enum):
+    """
+    Enumerations
+    """
+
+    # "Default" comment position algorithm. In other words, what `render()` would show prior to this enum's creation.
+    Default = auto()
+    # Indicates the comment should be at the top of the file.
+    TopOfFile = auto()
 
 
 class Node:
@@ -34,13 +46,16 @@ class Node:
         value: NodeValue | SentinelType = _sentinel,
         # TODO Future: Node comments should be Optional.
         comment: str = "",
+        comment_pos: CommentPosition = CommentPosition.Default,
         children: Optional[list["Node"]] = None,
         list_member_flag: bool = False,
         multiline_variant: MultilineVariant = MultilineVariant.NONE,
         key_flag: bool = False,
     ):
         """
-        Constructs a node
+        Constructs a node.
+
+        TODO members (or at least most members) of the `Node` class should be marked as private.
 
         :param value:               Value of the current node
         :param comment:             Comment on the line this node was found on
@@ -51,6 +66,7 @@ class Node:
         """
         self.value = value
         self.comment = comment
+        self.comment_pos = comment_pos
         self.children: list[Node] = children if children else []
         self.list_member_flag = list_member_flag
         self.multiline_variant = multiline_variant
@@ -129,6 +145,15 @@ class Node:
         :returns: True if the node represents only a comment. False otherwise.
         """
         return self.value == Node._sentinel and bool(self.comment) and not self.children
+
+    def is_tof_comment(self) -> bool:
+        """
+        Indicates if a line contains only a comment, located at the top of the file. When rendered, this will be a
+        comment only-line. This only applies to V0 recipes.
+
+        :returns: True if the node represents only a comment. False otherwise.
+        """
+        return self.is_comment() and self.comment_pos == CommentPosition.TopOfFile
 
     def is_empty_key(self) -> bool:
         """

--- a/conda_recipe_manager/parser/_node.py
+++ b/conda_recipe_manager/parser/_node.py
@@ -18,9 +18,9 @@ class CommentPosition(Enum):
     """
 
     # "Default" comment position algorithm. In other words, what `render()` would show prior to this enum's creation.
-    Default = auto()
+    DEFAULT = auto()
     # Indicates the comment should be at the top of the file.
-    TopOfFile = auto()
+    TOP_OF_FILE = auto()
 
 
 class Node:
@@ -46,7 +46,7 @@ class Node:
         value: NodeValue | SentinelType = _sentinel,
         # TODO Future: Node comments should be Optional.
         comment: str = "",
-        comment_pos: CommentPosition = CommentPosition.Default,
+        comment_pos: CommentPosition = CommentPosition.DEFAULT,
         children: Optional[list["Node"]] = None,
         list_member_flag: bool = False,
         multiline_variant: MultilineVariant = MultilineVariant.NONE,
@@ -59,6 +59,7 @@ class Node:
 
         :param value:               Value of the current node
         :param comment:             Comment on the line this node was found on
+        :param comment_pos:         Special enum indicating full-line comment positioning.
         :param children:            List of children nodes, descendants of this node
         :param list_member_flag:    Indicates if this node is part of a list
         :param multiline_variant:   Indicates if the node represents a multiline value AND which syntax variant is used
@@ -153,7 +154,7 @@ class Node:
 
         :returns: True if the node represents only a comment. False otherwise.
         """
-        return self.is_comment() and self.comment_pos == CommentPosition.TopOfFile
+        return self.is_comment() and self.comment_pos == CommentPosition.TOP_OF_FILE
 
     def is_empty_key(self) -> bool:
         """

--- a/tests/test_aux_files/parser_regressions/issue-366_quote_regressions_round_trip.yaml
+++ b/tests/test_aux_files/parser_regressions/issue-366_quote_regressions_round_trip.yaml
@@ -1,13 +1,13 @@
+# {% set soversion_comment = ".".join(version.split(".")[:3]) %}
+# Contains a number of regression issues found while working on Issue #366, but is round-trip-able.
+# We must preserve comments on variable assignment lines.
 {% set name = "types-toml" %}
 {% set version = "0.10.8.6" %}  # Foobar
 {% set soversion = ".".join(version.split(".")[:3]) %}
 {% set native_compiler_subdir = "linux-64" %}  # [linux]
 {% set am_version = "1.15" %}  # keep synchronized with build.sh
 
-# {% set soversion_comment = ".".join(version.split(".")[:3]) %}
-# Contains a number of regression issues found while working on Issue #366, but is round-trip-able.
-# We must preserve comments on variable assignment lines.
-# TODO FIX: When #384 is resolved, move the comments above the variable assignment
+# Package comment to verify #384
 package:
   name: {{ name|lower }}
   version: {{ version }}


### PR DESCRIPTION
Fixes #384 by adding a small hack to track comment positions in V0 recipe files. V1 does not suffer from this issue, given it uses a standard `context` section to set JINJA variables.