### PR TITLE
Adding click `help` support to click commands

### DIFF
--- a/conda_recipe_manager/commands/bump_recipe.py
+++ b/conda_recipe_manager/commands/bump_recipe.py
@@ -655,7 +655,8 @@ def _validate_interop_flags(build_num: bool, override_build_num: Optional[int], 
 # `Path` instance. This is caused by how `click` uses decorators. See these links for more detail:
 # - https://pytest-pyfakefs.readthedocs.io/en/latest/troubleshooting.html#pathlib-path-objects-created-outside-of-tests
 # - https://github.com/pytest-dev/pyfakefs/discussions/605
-@click.command(short_help="Bumps a recipe file to a new version.")
+CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
+@click.command(short_help="Bumps a recipe file to a new version.", context_settings=CONTEXT_SETTINGS)
 @click.argument("recipe_file_path", type=click.Path(exists=True, path_type=str))
 @click.option(
     "-o",

--- a/conda_recipe_manager/commands/bump_recipe.py
+++ b/conda_recipe_manager/commands/bump_recipe.py
@@ -655,7 +655,9 @@ def _validate_interop_flags(build_num: bool, override_build_num: Optional[int], 
 # `Path` instance. This is caused by how `click` uses decorators. See these links for more detail:
 # - https://pytest-pyfakefs.readthedocs.io/en/latest/troubleshooting.html#pathlib-path-objects-created-outside-of-tests
 # - https://github.com/pytest-dev/pyfakefs/discussions/605
-CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
+CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
+
+
 @click.command(short_help="Bumps a recipe file to a new version.", context_settings=CONTEXT_SETTINGS)
 @click.argument("recipe_file_path", type=click.Path(exists=True, path_type=str))
 @click.option(

--- a/conda_recipe_manager/commands/bump_recipe.py
+++ b/conda_recipe_manager/commands/bump_recipe.py
@@ -14,7 +14,7 @@ from typing import Final, NamedTuple, NoReturn, Optional, cast
 
 import click
 
-from conda_recipe_manager.commands.utils.types import ExitCode
+from conda_recipe_manager.commands.utils.types import CONTEXT_SETTINGS, ExitCode
 from conda_recipe_manager.fetcher.api import pypi
 from conda_recipe_manager.fetcher.artifact_fetcher import from_recipe as af_from_recipe
 from conda_recipe_manager.fetcher.base_artifact_fetcher import BaseArtifactFetcher
@@ -655,7 +655,6 @@ def _validate_interop_flags(build_num: bool, override_build_num: Optional[int], 
 # `Path` instance. This is caused by how `click` uses decorators. See these links for more detail:
 # - https://pytest-pyfakefs.readthedocs.io/en/latest/troubleshooting.html#pathlib-path-objects-created-outside-of-tests
 # - https://github.com/pytest-dev/pyfakefs/discussions/605
-CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
 
 
 @click.command(short_help="Bumps a recipe file to a new version.", context_settings=CONTEXT_SETTINGS)

--- a/conda_recipe_manager/commands/conda_recipe_manager.py
+++ b/conda_recipe_manager/commands/conda_recipe_manager.py
@@ -15,7 +15,8 @@ from conda_recipe_manager.commands.patch import patch
 from conda_recipe_manager.commands.rattler_bulk_build import rattler_bulk_build
 
 
-@click.group()
+CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
+@click.group(context_settings=CONTEXT_SETTINGS)
 @click.option(
     "-v",
     "--verbose",

--- a/conda_recipe_manager/commands/conda_recipe_manager.py
+++ b/conda_recipe_manager/commands/conda_recipe_manager.py
@@ -14,8 +14,9 @@ from conda_recipe_manager.commands.graph import graph
 from conda_recipe_manager.commands.patch import patch
 from conda_recipe_manager.commands.rattler_bulk_build import rattler_bulk_build
 
+CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
 
-CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
+
 @click.group(context_settings=CONTEXT_SETTINGS)
 @click.option(
     "-v",

--- a/conda_recipe_manager/commands/conda_recipe_manager.py
+++ b/conda_recipe_manager/commands/conda_recipe_manager.py
@@ -13,8 +13,7 @@ from conda_recipe_manager.commands.convert import convert
 from conda_recipe_manager.commands.graph import graph
 from conda_recipe_manager.commands.patch import patch
 from conda_recipe_manager.commands.rattler_bulk_build import rattler_bulk_build
-
-CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
+from conda_recipe_manager.commands.utils.types import CONTEXT_SETTINGS
 
 
 @click.group(context_settings=CONTEXT_SETTINGS)

--- a/conda_recipe_manager/commands/convert.py
+++ b/conda_recipe_manager/commands/convert.py
@@ -243,7 +243,8 @@ def _collect_issue_stats(project_name: str, issues: list[str], hist: dict[str, i
     return len(issues)
 
 
-@click.command(short_help="Converts a `meta.yaml` formatted-recipe file to the new `recipe.yaml` format.")
+CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
+@click.command(short_help="Converts a `meta.yaml` formatted-recipe file to the new `recipe.yaml` format.", context_settings=CONTEXT_SETTINGS)
 @click.argument("path", type=click.Path(exists=True, path_type=Path))
 @click.option(
     "--output",

--- a/conda_recipe_manager/commands/convert.py
+++ b/conda_recipe_manager/commands/convert.py
@@ -243,8 +243,13 @@ def _collect_issue_stats(project_name: str, issues: list[str], hist: dict[str, i
     return len(issues)
 
 
-CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
-@click.command(short_help="Converts a `meta.yaml` formatted-recipe file to the new `recipe.yaml` format.", context_settings=CONTEXT_SETTINGS)
+CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
+
+
+@click.command(
+    short_help="Converts a `meta.yaml` formatted-recipe file to the new `recipe.yaml` format.",
+    context_settings=CONTEXT_SETTINGS,
+)
 @click.argument("path", type=click.Path(exists=True, path_type=Path))
 @click.option(
     "--output",

--- a/conda_recipe_manager/commands/convert.py
+++ b/conda_recipe_manager/commands/convert.py
@@ -17,7 +17,7 @@ from typing import Final, Optional
 import click
 
 from conda_recipe_manager.commands.utils.print import print_err, print_messages, print_out
-from conda_recipe_manager.commands.utils.types import ExitCode
+from conda_recipe_manager.commands.utils.types import CONTEXT_SETTINGS, ExitCode
 from conda_recipe_manager.parser.enums import SchemaVersion
 from conda_recipe_manager.parser.recipe_parser_convert import RecipeParserConvert
 from conda_recipe_manager.parser.types import V0_FORMAT_RECIPE_FILE_NAME, V1_FORMAT_RECIPE_FILE_NAME
@@ -241,9 +241,6 @@ def _collect_issue_stats(project_name: str, issues: list[str], hist: dict[str, i
     if issues:
         recipes_lst.append(project_name)
     return len(issues)
-
-
-CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
 
 
 @click.command(

--- a/conda_recipe_manager/commands/graph.py
+++ b/conda_recipe_manager/commands/graph.py
@@ -14,7 +14,7 @@ from typing import Final, Optional
 import click
 
 from conda_recipe_manager.commands.utils.print import print_err
-from conda_recipe_manager.commands.utils.types import ExitCode
+from conda_recipe_manager.commands.utils.types import CONTEXT_SETTINGS, ExitCode
 from conda_recipe_manager.grapher.recipe_graph import PackageStats, RecipeGraph
 from conda_recipe_manager.grapher.recipe_graph_from_disk import RecipeGraphFromDisk
 from conda_recipe_manager.grapher.types import GraphDirection, GraphType, PackageStatsEncoder
@@ -59,9 +59,6 @@ def _parse_plot_options(recipe_graph: RecipeGraph, g_type: str, dir_str: Optiona
 
     recipe_graph.plot(GraphType(g_type), direction=direction, package=pkg)
     return True
-
-
-CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
 
 
 @click.command(short_help="Interactive CLI for examining recipe dependency graphs.", context_settings=CONTEXT_SETTINGS)

--- a/conda_recipe_manager/commands/graph.py
+++ b/conda_recipe_manager/commands/graph.py
@@ -61,7 +61,9 @@ def _parse_plot_options(recipe_graph: RecipeGraph, g_type: str, dir_str: Optiona
     return True
 
 
-CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
+CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
+
+
 @click.command(short_help="Interactive CLI for examining recipe dependency graphs.", context_settings=CONTEXT_SETTINGS)
 @click.argument("path", type=click.Path(exists=True, path_type=Path, file_okay=False))
 def graph(path: Path) -> None:

--- a/conda_recipe_manager/commands/graph.py
+++ b/conda_recipe_manager/commands/graph.py
@@ -61,7 +61,8 @@ def _parse_plot_options(recipe_graph: RecipeGraph, g_type: str, dir_str: Optiona
     return True
 
 
-@click.command(short_help="Interactive CLI for examining recipe dependency graphs.")
+CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
+@click.command(short_help="Interactive CLI for examining recipe dependency graphs.", context_settings=CONTEXT_SETTINGS)
 @click.argument("path", type=click.Path(exists=True, path_type=Path, file_okay=False))
 def graph(path: Path) -> None:
     """

--- a/conda_recipe_manager/commands/patch.py
+++ b/conda_recipe_manager/commands/patch.py
@@ -53,7 +53,8 @@ def _pre_patch_validate(
 # `Path` instance. This is caused by how `click` uses decorators. See these links for more detail:
 # - https://pytest-pyfakefs.readthedocs.io/en/latest/troubleshooting.html#pathlib-path-objects-created-outside-of-tests
 # - https://github.com/pytest-dev/pyfakefs/discussions/605
-@click.command(short_help="Modify recipe files with JSON patch blobs.")
+CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
+@click.command(short_help="Modify recipe files with JSON patch blobs.", context_settings=CONTEXT_SETTINGS)
 @click.argument("json_patch_file_path", type=click.Path(exists=True, path_type=str))
 @click.argument("recipe_file_path", type=click.Path(exists=True, path_type=str))
 def patch(json_patch_file_path: str, recipe_file_path: str) -> None:

--- a/conda_recipe_manager/commands/patch.py
+++ b/conda_recipe_manager/commands/patch.py
@@ -12,7 +12,7 @@ from typing import cast
 import click
 
 from conda_recipe_manager.commands.utils.print import print_err
-from conda_recipe_manager.commands.utils.types import ExitCode
+from conda_recipe_manager.commands.utils.types import CONTEXT_SETTINGS, ExitCode
 from conda_recipe_manager.parser.exceptions import JsonPatchValidationException
 from conda_recipe_manager.parser.recipe_parser import RecipeParser
 from conda_recipe_manager.types import JsonPatchType
@@ -53,7 +53,6 @@ def _pre_patch_validate(
 # `Path` instance. This is caused by how `click` uses decorators. See these links for more detail:
 # - https://pytest-pyfakefs.readthedocs.io/en/latest/troubleshooting.html#pathlib-path-objects-created-outside-of-tests
 # - https://github.com/pytest-dev/pyfakefs/discussions/605
-CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
 
 
 @click.command(short_help="Modify recipe files with JSON patch blobs.", context_settings=CONTEXT_SETTINGS)

--- a/conda_recipe_manager/commands/patch.py
+++ b/conda_recipe_manager/commands/patch.py
@@ -53,7 +53,9 @@ def _pre_patch_validate(
 # `Path` instance. This is caused by how `click` uses decorators. See these links for more detail:
 # - https://pytest-pyfakefs.readthedocs.io/en/latest/troubleshooting.html#pathlib-path-objects-created-outside-of-tests
 # - https://github.com/pytest-dev/pyfakefs/discussions/605
-CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
+CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
+
+
 @click.command(short_help="Modify recipe files with JSON patch blobs.", context_settings=CONTEXT_SETTINGS)
 @click.argument("json_patch_file_path", type=click.Path(exists=True, path_type=str))
 @click.argument("recipe_file_path", type=click.Path(exists=True, path_type=str))

--- a/conda_recipe_manager/commands/utils/types.py
+++ b/conda_recipe_manager/commands/utils/types.py
@@ -6,6 +6,10 @@ from __future__ import annotations
 
 from enum import IntEnum
 
+# Standard Click context settings used across all commands to ensure consistent
+# help option behavior
+CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
+
 
 class ExitCode(IntEnum):
     """


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Resolving issue #380 
- adding CONTEXT_SETTINGS to the commands to allow both `-h`, and `--help` for `crm` and `crm <command>`

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->



<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-recipe-manager/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-recipe-manager/blob/main/CONTRIBUTING.md -->
