### PR TITLE
Fix issue #394

### DIFF
--- a/conda_recipe_manager/parser/_types.py
+++ b/conda_recipe_manager/parser/_types.py
@@ -229,7 +229,7 @@ class Regex:
     )
     JINJA_FUNCTION_IDX_ACCESS: Final[re.Pattern[str]] = re.compile(r"(.+)\[(-?\d+)\]")
     JINJA_FUNCTION_ADD_CONCAT: Final[re.Pattern[str]] = re.compile(
-        r"([\"\']?[\w\.!]+[\"\']?)[ \t]*\+[ \t]*([\"\']?[\w\.!]+[\"\']?)"
+        r"([\"\']?[\w\.!]+[\"\']?)[ \t]+\+[ \t]*([\"\']?[\w\.!]+[\"\']?)"
     )
     # `match()` is a JINJA function available in the V1 recipe format
     JINJA_FUNCTION_MATCH: Final[re.Pattern[str]] = re.compile(r"match\(.*,.*\)")

--- a/tests/parser/test_recipe_parser_convert.py
+++ b/tests/parser/test_recipe_parser_convert.py
@@ -286,11 +286,10 @@ def test_pre_process_recipe_text(input_file: str, expected_file: str) -> None:
             ],
         ),
         # Issue #394: variable with a "+" (version with local version identifier) not treated as string
-        pytest.param(
+        (
             "parser_regressions/issue-394_regression.yaml",
             [],
             [],
-            marks=pytest.mark.xfail(reason="Issue #394"),
         ),
         # TODO complete: The `rust.yaml` test contains many edge cases and selectors that aren't directly supported in
         # the V1 recipe format

--- a/tests/parser/test_recipe_parser_convert.py
+++ b/tests/parser/test_recipe_parser_convert.py
@@ -285,6 +285,13 @@ def test_pre_process_recipe_text(input_file: str, expected_file: str) -> None:
                 "Field at `/about/license_family` is no longer supported.",
             ],
         ),
+        # Issue #394: variable with a "+" (version with local version identifier) not treated as string
+        pytest.param(
+            "parser_regressions/issue-394_regression.yaml",
+            [],
+            [],
+            marks=pytest.mark.xfail(reason="Issue #394"),
+        ),
         # TODO complete: The `rust.yaml` test contains many edge cases and selectors that aren't directly supported in
         # the V1 recipe format
         # (

--- a/tests/test_aux_files/parser_regressions/issue-394_regression.yaml
+++ b/tests/test_aux_files/parser_regressions/issue-394_regression.yaml
@@ -1,0 +1,39 @@
+{% set name = "mylib" %}
+{% set version = "1.2.1.dev1+g3df5418" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: file:///tmp/dist/mylib-1.2.1.dev1%2Bg3df5418.tar.gz
+  sha256: 9bdff8785453464cd0932867694a15a4a322cf859693990820fdbf04272bf022
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python >=3.9
+    - setuptools >=45
+    - setuptools-scm >=6.2
+    - pip
+  run:
+    - python >=3.9
+    - numpy
+
+test:
+  imports:
+    - mylib
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://gitlab.com/mygroup/mylib
+  summary: My great Python library
+  license: GPL-3.0-or-later
+  license_file: LICENSE

--- a/tests/test_aux_files/parser_regressions/v1_format/v1_issue-394_regression.yaml
+++ b/tests/test_aux_files/parser_regressions/v1_format/v1_issue-394_regression.yaml
@@ -1,0 +1,40 @@
+schema_version: 1
+
+context:
+  name: mylib
+  version: 1.2.1.dev1+g3df5418
+
+package:
+  name: ${{ name|lower }}
+  version: ${{ version }}
+
+source:
+  url: file:///tmp/dist/mylib-1.2.1.dev1%2Bg3df5418.tar.gz
+  sha256: 9bdff8785453464cd0932867694a15a4a322cf859693990820fdbf04272bf022
+
+build:
+  number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python >=3.9
+    - setuptools >=45
+    - setuptools-scm >=6.2
+    - pip
+  run:
+    - python >=3.9
+    - numpy
+
+tests:
+  - python:
+      imports:
+        - mylib
+      pip_check: true
+
+about:
+  summary: My great Python library
+  license: GPL-3.0-or-later
+  license_file: LICENSE
+  homepage: https://gitlab.com/mygroup/mylib


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Add a test for issue 394 and try to fix it.

To avoid strings with a `+`, like `1.2.1.dev1+g3df5418` to be treated as an expression instead of a string, I modified the `JINJA_FUNCTION_ADD_CONCAT` regular expression to force a space before the `+`.
There might be a better way, as it's not 100% correct. A space isn't required in the expression. In practice, I have always seen it (like in `epoch + '!' + so_number`) as it's much more readable.
We could wrongly interpret an expression as a string with this change.

On the other side, I don't see how to modify the regular expression in a different way to not match `1.2.1.dev1+g3df5418`.

Looking at the original yaml file, when we have a string, we have quotes `{% set version = "1.2.1.dev1+g3df5418" %}`
And we don't in expressions: `{% set version = version_prefix + '.' + release_date %}`.

That would probably be a better way to identify expressions, but from what I saw, this information is lost after parsing, when getting the name / value.


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-recipe-manager/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-recipe-manager/blob/main/CONTRIBUTING.md -->
