### PR TITLE
Attempts to fix double fake filesystem error

### DIFF
--- a/tests/commands/test_patch.py
+++ b/tests/commands/test_patch.py
@@ -2,10 +2,11 @@
 :Description: Tests the `patch` CLI
 """
 
+from typing import Final
+
 import pytest
 from click.testing import CliRunner
 from pyfakefs.fake_filesystem import FakeFilesystem
-from pyfakefs.fake_filesystem_unittest import Patcher
 
 from conda_recipe_manager.commands import patch
 from conda_recipe_manager.commands.utils.types import ExitCode
@@ -27,13 +28,13 @@ def test_patch_cli(json_patch_file: str, fs: FakeFilesystem) -> None:
 
     :param fs: pyfakefs fixture used to replace the file system
     """
-    runner = CliRunner()
+    runner: Final = CliRunner()
     fs.add_real_directory(get_test_path(), read_only=False)
 
-    json_patch_path = get_test_path() / json_patch_file
-    recipe_file_path = get_test_path() / "simple-recipe.yaml"
+    json_patch_path: Final = get_test_path() / json_patch_file
+    recipe_file_path: Final = get_test_path() / "simple-recipe.yaml"
 
-    result = runner.invoke(patch.patch, [str(json_patch_path), str(recipe_file_path)])
+    result: Final = runner.invoke(patch.patch, [str(json_patch_path), str(recipe_file_path)])
     assert result.exit_code == ExitCode.SUCCESS
 
 
@@ -43,13 +44,13 @@ def test_non_existent_recipe_file(fs: FakeFilesystem) -> None:
 
     :param fs: pyfakefs fixture used to replace the file system
     """
-    runner = CliRunner()
+    runner: Final = CliRunner()
     fs.add_real_directory(get_test_path(), read_only=False)
 
-    json_patch_path = get_test_path() / "patch/json_patch.json"
-    recipe_file_path = "non/existent/path"
+    json_patch_path: Final = get_test_path() / "patch/json_patch.json"
+    recipe_file_path: Final = "non/existent/path"
 
-    result = runner.invoke(patch.patch, [str(json_patch_path), recipe_file_path])
+    result: Final = runner.invoke(patch.patch, [str(json_patch_path), recipe_file_path])
     assert result.exit_code == ExitCode.CLICK_USAGE
 
 
@@ -59,13 +60,13 @@ def test_non_existent_json_patch_file(fs: FakeFilesystem) -> None:
 
     :param fs: pyfakefs fixture used to replace the file system
     """
-    runner = CliRunner()
+    runner: Final = CliRunner()
     fs.add_real_directory(get_test_path(), read_only=False)
 
-    json_patch_path = "non/existent/path"
-    recipe_file_path = get_test_path() / "simple-recipe.yaml"
+    json_patch_path: Final = "non/existent/path"
+    recipe_file_path: Final = get_test_path() / "simple-recipe.yaml"
 
-    result = runner.invoke(patch.patch, [json_patch_path, str(recipe_file_path)])
+    result: Final = runner.invoke(patch.patch, [json_patch_path, str(recipe_file_path)])
     assert result.exit_code == ExitCode.CLICK_USAGE
 
 
@@ -80,13 +81,13 @@ def test_patch_cli_bad_recipe_file(recipe_file: str, fs: FakeFilesystem) -> None
 
     :param fs: pyfakefs fixture used to replace the file system
     """
-    runner = CliRunner()
+    runner: Final = CliRunner()
     fs.add_real_directory(get_test_path(), read_only=False)
 
-    json_patch_path = get_test_path() / "patch/json_patch.json"
-    bad_recipe_file_path = get_test_path() / recipe_file
+    json_patch_path: Final = get_test_path() / "patch/json_patch.json"
+    bad_recipe_file_path: Final = get_test_path() / recipe_file
 
-    result = runner.invoke(patch.patch, [str(json_patch_path), str(bad_recipe_file_path)])
+    result: Final = runner.invoke(patch.patch, [str(json_patch_path), str(bad_recipe_file_path)])
     assert result.exit_code == ExitCode.ILLEGAL_OPERATION
 
 
@@ -97,15 +98,13 @@ def test_patch_cli_invalid_json_patch_operation(request: pytest.FixtureRequest) 
 
     :param fs: pyfakefs fixture used to replace the file system
     """
-
-    runner = CliRunner()
+    runner: Final = CliRunner()
     request.getfixturevalue("fs").add_real_directory(get_test_path(), read_only=False)  # type: ignore[misc]
 
-    faulty_json_patch_path = get_test_path() / "patch/bad_json_patch_files/bad_json_patch.json"
-    recipe_file_path = get_test_path() / "simple-recipe.yaml"
+    faulty_json_patch_path: Final = get_test_path() / "patch/bad_json_patch_files/bad_json_patch.json"
+    recipe_file_path: Final = get_test_path() / "simple-recipe.yaml"
 
-    with Patcher(modules_to_reload=[patch]):  # here patch is the patch.py module
-        result = runner.invoke(patch.patch, [str(faulty_json_patch_path), str(recipe_file_path)])
+    result: Final = runner.invoke(patch.patch, [str(faulty_json_patch_path), str(recipe_file_path)])
     # this JSON_ERROR comes from JsonPatchValidationException being raised, not from JsonDecodeError
     assert result.exit_code == ExitCode.JSON_ERROR
 
@@ -117,13 +116,13 @@ def test_patch_cli_bad_json_file(fs: FakeFilesystem) -> None:
     :param fs: pyfakefs fixture used to replace the file system
     """
 
-    runner = CliRunner()
+    runner: Final = CliRunner()
     fs.add_real_directory(get_test_path(), read_only=False)
 
-    faulty_json_patch_path = get_test_path() / "patch/bad_json_patch_files/empty_json.json"
-    recipe_file_path = get_test_path() / "simple-recipe.yaml"
+    faulty_json_patch_path: Final = get_test_path() / "patch/bad_json_patch_files/empty_json.json"
+    recipe_file_path: Final = get_test_path() / "simple-recipe.yaml"
 
-    result = runner.invoke(patch.patch, [str(faulty_json_patch_path), str(recipe_file_path)])
+    result: Final = runner.invoke(patch.patch, [str(faulty_json_patch_path), str(recipe_file_path)])
     # this json error comes from `JSONDecodeError` exception occuring when the provided json file cannot be read/decoded
     assert result.exit_code == ExitCode.JSON_ERROR
 


### PR DESCRIPTION
- Attempts to fix the double fake filesystem error only seen in the `rattler-build` GitHub workflow test
- Also improved `Final` usage in the afflicted test file.
