### PR TITLE
fix: use `python_min` in skip conditions for noarch Python recipes

### DIFF
--- a/tests/parser/test_recipe_parser_convert.py
+++ b/tests/parser/test_recipe_parser_convert.py
@@ -314,6 +314,12 @@ def test_pre_process_recipe_text(input_file: str, expected_file: str) -> None:
             [],
             [],
         ),
+        # Issue #479: noarch python recipes should use `python_min` instead of `python` in skip conditions
+        (
+            "noarch-python-skip.yaml",
+            [],
+            [],
+        ),
     ],
 )
 def test_render_to_v1_recipe_format(file: str, errors: list[str], warnings: list[str]) -> None:

--- a/tests/test_aux_files/noarch-python-skip.yaml
+++ b/tests/test_aux_files/noarch-python-skip.yaml
@@ -1,0 +1,37 @@
+{% set name = "noarch-python-skip" %}
+{% set version = "1.0.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
+
+build:
+  number: 0
+  noarch: python
+  skip: true  # [py<310]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python >=3.10
+    - pip
+  run:
+    - python >=3.10
+
+test:
+  imports:
+    - noarch_python_skip
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/example/noarch-python-skip
+  summary: Test package for noarch python skip condition conversion
+  license: MIT
+  license_file: LICENSE

--- a/tests/test_aux_files/v1_format/v1_noarch-python-skip.yaml
+++ b/tests/test_aux_files/v1_format/v1_noarch-python-skip.yaml
@@ -1,0 +1,38 @@
+schema_version: 1
+
+context:
+  name: noarch-python-skip
+  version: 1.0.0
+
+package:
+  name: ${{ name|lower }}
+  version: ${{ version }}
+
+source:
+  url: https://pypi.io/packages/source/${{ name[0] }}/${{ name }}/${{ name }}-${{ version }}.tar.gz
+  sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
+
+build:
+  number: 0
+  skip: match(python_min, "<3.10")
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python >=3.10
+    - pip
+  run:
+    - python >=3.10
+
+tests:
+  - python:
+      imports:
+        - noarch_python_skip
+      pip_check: true
+
+about:
+  summary: Test package for noarch python skip condition conversion
+  license: MIT
+  license_file: LICENSE
+  homepage: https://github.com/example/noarch-python-skip


### PR DESCRIPTION
## Summary

Per CFEP-25 standards, V1 noarch Python recipes only define `python_min` in their variant configuration, not `python`. This PR fixes the V0→V1 recipe conversion to use `python_min` instead of `python` in skip condition match expressions for noarch Python packages.

## Changes

- Added `_is_noarch_python()` helper method to detect `noarch: python` recipes
- Modified `_upgrade_selectors_to_conditionals()` to use `python_min` for noarch Python recipes
- Added test case with `noarch-python-skip.yaml` fixture

## Before

```yaml
build:
  skip: match(python, "<3.10")
  noarch: python
```

## After

```yaml
build:
  skip: match(python_min, "<3.10")
  noarch: python
```

## Related Issues

- Fixes #479
- Downstream issue in grayskull: https://github.com/conda/grayskull/issues/644
- Downstream PR in cf-scripts: https://github.com/regro/cf-scripts/pull/5306

## Test Plan

- [x] Added unit test `noarch-python-skip.yaml` that verifies the fix
- [x] Verified existing `selector-match-upgrades.yaml` test still passes (non-noarch recipes still use `python`)
- [x] All 34 tests in `test_recipe_parser_convert.py` pass

---

*This PR was generated with the assistance of [Claude Code](https://claude.ai/code)*