### PR TITLE
Add missing evalidate dependency to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
   "jsonschema",
   "requests",
   "gitpython",
+  "evalidate>=2.0.3,<3.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

- evalidate is imported in conda_recipe_manager/parser/selector_parser.py and listed as a dependency in both environment.yaml and recipe/meta.yaml, but is missing from pyproject.toml.
- This causes editable installs (pip install -e .) to fail when testing a PR branch, since evalidate is not pulled in as a dependency.

Made with [Cursor](https://cursor.com)