### PR TITLE
Fix converting `python_version_independent`

### DIFF
--- a/conda_recipe_manager/parser/recipe_parser_convert.py
+++ b/conda_recipe_manager/parser/recipe_parser_convert.py
@@ -619,6 +619,9 @@ class RecipeParserConvert(RecipeParserDeps):
             # `build/force_use_keys` -> `build/variant/use_keys`
             self._patch_move_new_path(build_path, "/force_use_keys", "/variant", "use_keys")
 
+            # `build/python_version_independent` -> `build/python/version_independent`
+            self._patch_move_new_path(build_path, "/python_version_independent", "/python", "version_independent")
+
             # New `prefix_detection` section changes
             # NOTE: There is a new `force_file_type` field that may map to an unknown field that conda supports.
             self._patch_move_new_path(build_path, "/ignore_prefix_files", "/prefix_detection", "/ignore")

--- a/tests/parser/test_recipe_parser_convert.py
+++ b/tests/parser/test_recipe_parser_convert.py
@@ -514,6 +514,16 @@ def test_pre_process_recipe_text(input_file: str, expected_file: str) -> None:
             [],
             [],
         ),
+        (
+            "example-abi3.yaml",
+            [],
+            [
+                "Recipe upgrades cannot currently upgrade ambiguous version constraints on "
+                "dependencies that use variables: {{ compiler('c') }}",
+                "Recipe upgrades cannot currently upgrade ambiguous version constraints on "
+                "dependencies that use variables: {{ stdlib('c') }}",
+            ],
+        ),
     ],
 )
 def test_render_to_v1_recipe_format(file: str, errors: list[str], warnings: list[str]) -> None:

--- a/tests/test_aux_files/example-abi3.yaml
+++ b/tests/test_aux_files/example-abi3.yaml
@@ -1,0 +1,46 @@
+package:
+  name: python-abi3-package-sample
+  version: 0.0.1
+
+source:
+  url: https://github.com/joerick/python-abi3-package-sample/archive/6f74ae7b31e58ef5f8f09b647364854122e61155.tar.gz
+  sha256: e81fd4d4c4f5b7bc9786d9ee990afc659e14a25ce11182b7b69f826407cc1718
+
+build:
+  number: 0
+  python_version_independent: true   # [is_abi3]
+  script: {{ PYTHON }} -m pip install . -vv
+  skip: True                         # [is_abi3 and not is_python_min]
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ stdlib('c') }}
+  host:
+    - python-abi3                    # [is_abi3]
+    - python
+    - pip
+    - setuptools
+  run:
+    - python
+
+test:
+  imports:
+    - spam
+  requires:
+    - pip
+    - abi3audit                      # [is_abi3]
+  commands:
+    - pip check
+    - abi3audit $SP_DIR/spam.abi3.so -s -v --assume-minimum-abi3 {{ python_min }}   # [unix and is_abi3]
+    - abi3audit %SP_DIR%/spam.pyd -s -v --assume-minimum-abi3 {{ python_min }}      # [win and is_abi3]
+
+about:
+  home: https://github.com/joerick/python-abi3-package-sample
+  summary: 'ABI3 example'
+  license: Apache-2.0
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - isuruf

--- a/tests/test_aux_files/v1_format/v1_example-abi3.yaml
+++ b/tests/test_aux_files/v1_format/v1_example-abi3.yaml
@@ -1,0 +1,55 @@
+schema_version: 1
+
+package:
+  name: python-abi3-package-sample
+  version: "0.0.1"
+
+source:
+  url: https://github.com/joerick/python-abi3-package-sample/archive/6f74ae7b31e58ef5f8f09b647364854122e61155.tar.gz
+  sha256: e81fd4d4c4f5b7bc9786d9ee990afc659e14a25ce11182b7b69f826407cc1718
+
+build:
+  number: 0
+  skip: is_abi3 and not is_python_min
+  script: ${{ PYTHON }} -m pip install . -vv
+  python:
+    version_independent: ${{ true if is_abi3 }}
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - ${{ stdlib('c') }}
+  host:
+    - if: is_abi3
+      then: python-abi3
+    - python
+    - pip
+    - setuptools
+  run:
+    - python
+
+tests:
+  - python:
+      imports:
+        - spam
+  - requirements:
+      run:
+        - pip
+        - if: is_abi3
+          then: abi3audit
+    script:
+      - pip check
+      - if: unix and is_abi3
+        then: abi3audit $SP_DIR/spam.abi3.so -s -v --assume-minimum-abi3 ${{ python_min }}
+      - if: win and is_abi3
+        then: abi3audit %SP_DIR%/spam.pyd -s -v --assume-minimum-abi3 ${{ python_min }}
+
+about:
+  summary: ABI3 example
+  license: Apache-2.0
+  license_file: LICENSE
+  homepage: https://github.com/joerick/python-abi3-package-sample
+
+extra:
+  recipe-maintainers:
+    - isuruf


### PR DESCRIPTION
### Description

Fix converting `python_version_independent` into `python/version_independent` for v1 recipes, per [CEP-0020](https://github.com/conda/ceps/blob/main/cep-0020.md).

Fixes #481

