### PR TITLE
fix: handle fn field conversion for archive source files

### DIFF
--- a/conda_recipe_manager/parser/_types.py
+++ b/conda_recipe_manager/parser/_types.py
@@ -307,6 +307,13 @@ class Regex:
     # Regex to detect output section paths
     OUTPUT_SECTION_PATH: Final[re.Pattern[str]] = re.compile(r"^/outputs/\d+")
 
+    # Regex to detect archive file extensions (for source files)
+    # These archives are automatically extracted by rattler-build, but setting `file_name` disables extraction
+    # Based on rattler-build documentation: .tar.gz, .zip, .7z, etc.
+    ARCHIVE_FILE_EXTENSION: Final[re.Pattern[str]] = re.compile(
+        r"\.(tar(\.(gz|bz2|xz|zst|lz4|lzma))?|tgz|tbz2|txz|zip|7z|rar|ar|cpio|shar|iso|deb|rpm)(\s*$|\s*#)"
+    )
+
 
 class StringLoader(SafeLoader):
     """

--- a/conda_recipe_manager/parser/recipe_parser_convert.py
+++ b/conda_recipe_manager/parser/recipe_parser_convert.py
@@ -466,8 +466,36 @@ class RecipeParserConvert(RecipeParserDeps):
                         MessageCategory.WARNING, "HG (Mercurial) packages are no longer supported in the V1 format"
                     )
 
-                # Basic renaming transformations
-                self._patch_move_base_path(src_path, "/fn", "/file_name")
+                # Handle `fn` field conversion to `file_name`
+                # Issue #500: For archive source files, converting `fn` to `file_name` changes behavior
+                # In V1, `file_name` on archives disables automatic extraction, which is not desired
+                fn_path = RecipeParser.append_to_path(src_path, "/fn")
+                if self._v1_recipe.contains_value(fn_path):
+                    fn_value = cast(Optional[str], self._v1_recipe.get_value(fn_path, default=None))
+                    url_value = cast(Optional[str], self._v1_recipe.get_value(RecipeParser.append_to_path(src_path, "url"), default=None))
+                    
+                    # Check if this is an archive source by checking either the fn value or the url
+                    is_archive_source = False
+                    if fn_value is not None and Regex.ARCHIVE_FILE_EXTENSION.search(fn_value):
+                        is_archive_source = True
+                    elif url_value is not None and Regex.ARCHIVE_FILE_EXTENSION.search(url_value):
+                        is_archive_source = True
+                    
+                    if is_archive_source:
+                        # For archive sources, remove `fn` and warn the user
+                        # The user should manually handle this case as there's no direct equivalent
+                        self._patch_and_log({"op": "remove", "path": fn_path})
+                        self._msg_tbl.add_message(
+                            MessageCategory.WARNING,
+                            f"Field `fn` at `{src_path}/fn` was removed. `file_name` cannot be used for "
+                            "archive sources (.tar.gz, .zip, .7z, etc.) as it disables automatic extraction. "
+                            "If a specific file name is needed, consider using a non-archive URL or manual extraction."
+                        )
+                    else:
+                        # For non-archive sources, perform the normal conversion
+                        self._patch_move_base_path(src_path, "/fn", "/file_name")
+
+                # Basic renaming transformations (other than fn, which is handled above)
                 self._patch_move_base_path(src_path, "/folder", "/target_directory")
 
                 # `git` source transformations (`conda` does not appear to support all of the new features)

--- a/tests/parser/test_recipe_parser_convert.py
+++ b/tests/parser/test_recipe_parser_convert.py
@@ -82,6 +82,9 @@ def test_pre_process_recipe_text(input_file: str, expected_file: str) -> None:
             "pytest-pep8.yaml",
             [],
             [
+                "Field `fn` at `/source/fn` was removed. `file_name` cannot be used for "
+                "archive sources (.tar.gz, .zip, .7z, etc.) as it disables automatic extraction. "
+                "If a specific file name is needed, consider using a non-archive URL or manual extraction.",
                 "Field at `/about/doc_source_url` is no longer supported.",
             ],
         ),
@@ -140,6 +143,9 @@ def test_pre_process_recipe_text(input_file: str, expected_file: str) -> None:
             "boto.yaml",
             [],
             [
+                "Field `fn` at `/source/fn` was removed. `file_name` cannot be used for "
+                "archive sources (.tar.gz, .zip, .7z, etc.) as it disables automatic extraction. "
+                "If a specific file name is needed, consider using a non-archive URL or manual extraction.",
                 "Field at `/about/doc_source_url` is no longer supported.",
             ],
         ),
@@ -165,6 +171,9 @@ def test_pre_process_recipe_text(input_file: str, expected_file: str) -> None:
                     ' use variables: {{ pin_subpackage("libnvpl-fft" ~ somajor ) }}'
                 ),
                 "The following key(s) contain partially unsupported syntax: soversion",
+                "Field `fn` at `/source/fn` was removed. `file_name` cannot be used for "
+                "archive sources (.tar.gz, .zip, .7z, etc.) as it disables automatic extraction. "
+                "If a specific file name is needed, consider using a non-archive URL or manual extraction.",
                 "No `license` provided in `/about`",
             ],
         ),
@@ -173,6 +182,9 @@ def test_pre_process_recipe_text(input_file: str, expected_file: str) -> None:
             "parser_regressions/issue-366_quote_regressions.yaml",
             [],
             [
+                "Field `fn` at `/source/fn` was removed. `file_name` cannot be used for "
+                "archive sources (.tar.gz, .zip, .7z, etc.) as it disables automatic extraction. "
+                "If a specific file name is needed, consider using a non-archive URL or manual extraction.",
                 "The following key(s) contain partially unsupported syntax: soversion",
                 "No `license` provided in `/about`",
             ],

--- a/tests/test_aux_files/parser_regressions/v1_format/v1_issue-366_quote_regressions.yaml
+++ b/tests/test_aux_files/parser_regressions/v1_format/v1_issue-366_quote_regressions.yaml
@@ -18,7 +18,6 @@ package:
 source:
   url: https://pypi.io/packages/${{name}}/source/${{version}}/${{version}}/${{version}}
   sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
-  file_name: ${{ name }}-${{ version }}.tar.gz
 
 build:
   number: 0

--- a/tests/test_aux_files/parser_regressions/v1_format/v1_regression_jinja_sub.yaml
+++ b/tests/test_aux_files/parser_regressions/v1_format/v1_regression_jinja_sub.yaml
@@ -12,7 +12,6 @@ package:
 source:
   url: https://pypi.io/packages/${{name}}/source/${{version}}/${{version}}/${{version}}
   sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
-  file_name: ${{ name }}-${{ version }}.tar.gz
 
 build:
   number: 0

--- a/tests/test_aux_files/v1_format/v1_boto.yaml
+++ b/tests/test_aux_files/v1_format/v1_boto.yaml
@@ -11,7 +11,6 @@ package:
 source:
   url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/${{ name }}-${{ version }}.tar.gz
   sha256: ea0d3b40a2d852767be77ca343b58a9e3a4b00d9db440efb8da74b4e58025e5a
-  file_name: ${{ name }}-${{ version }}.tar.gz
 
 build:
   number: 0

--- a/tests/test_aux_files/v1_format/v1_pytest-pep8.yaml
+++ b/tests/test_aux_files/v1_format/v1_pytest-pep8.yaml
@@ -12,7 +12,6 @@ package:
 source:
   url: https://pypi.io/packages/source/${{ name[0] }}/${{ name }}/${{ name }}-${{ version }}.tar.gz
   sha256: ${{ sha256 }}
-  file_name: ${{ name }}-${{ version }}.tar.gz
 
 build:
   number: 1


### PR DESCRIPTION
Fixes #500

For archive source files (.tar.gz, .zip, .7z, etc.), converting `fn` to `file_name` changes behavior in V1 format. In V1, `file_name` on archives disables automatic extraction, which is not desired.

**Changes:**
- Add `ARCHIVE_FILE_EXTENSION` regex to detect archive file extensions
- For archive sources, remove `fn` field and warn user
- For non-archive sources, perform normal `fn` -> `file_name` conversion
- Update tests to verify the new behavior

**Testing:**
- Updated test files to reflect the new behavior
- Archive sources now correctly remove `fn` with a warning
- Non-archive sources still convert `fn` to `file_name`

This ensures that archive sources maintain automatic extraction behavior when converting from V0 to V1 format.