### PR TITLE
Allow duplicate keys in convert command

### DIFF
--- a/conda_recipe_manager/commands/convert.py
+++ b/conda_recipe_manager/commands/convert.py
@@ -138,7 +138,7 @@ def convert_file(
         )
 
     # Parse the recipe
-    base_flags = RecipeReaderFlags.NONE
+    base_flags = RecipeReaderFlags.ALLOW_DUPLICATE_KEYS
     if also_test_latest_python:
         base_flags |= RecipeReaderFlags.ALSO_TEST_LATEST_PYTHON
     parser: RecipeParserConvert


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Since v0 recipes can have duplicate keys with preprocessing selectors, it's good to enable this option by default.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-recipe-manager/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-recipe-manager/blob/main/CONTRIBUTING.md -->
