### PR TITLE
python and noarch Improvements for `VariantsManager`

### DIFF
--- a/conda_recipe_manager/parser/recipe_reader.py
+++ b/conda_recipe_manager/parser/recipe_reader.py
@@ -55,7 +55,13 @@ from conda_recipe_manager.parser.exceptions import (
     SentinelTypeEvaluationException,
 )
 from conda_recipe_manager.parser.selector_parser import SelectorParser
-from conda_recipe_manager.parser.types import TAB_AS_SPACES, TAB_SPACE_COUNT, MultilineVariant, RecipeReaderFlags
+from conda_recipe_manager.parser.types import (
+    TAB_AS_SPACES,
+    TAB_SPACE_COUNT,
+    MultilineVariant,
+    NoArchType,
+    RecipeReaderFlags,
+)
 from conda_recipe_manager.parser.v0_recipe_formatter import V0RecipeFormatter
 from conda_recipe_manager.types import PRIMITIVES_NO_NONE_TUPLE, PRIMITIVES_TUPLE, JsonType, Primitives, SentinelType
 from conda_recipe_manager.utils.cryptography.hashing import hash_str
@@ -1467,6 +1473,21 @@ class RecipeReader(IsModifiable):
                         continue
                     return True
         return False
+
+    def get_noarch_type(self) -> NoArchType:
+        """
+        Convenience function that returns an enumerated value indicating the `noarch` classification for this recipe.
+
+        :returns: The `noarch` classification of the recipe.
+        """
+        noarch_set: Final = set(NoArchType)
+        noarch: Final = optional_str(self.get_value("/build/noarch", default=None))
+        if noarch is None:
+            return NoArchType.NONE
+        noarch_sanitized: Final = noarch.strip().lower()
+        if noarch_sanitized not in noarch_set:
+            return NoArchType.NONE
+        return NoArchType(noarch_sanitized)
 
     def get_package_paths(self) -> list[str]:
         """

--- a/conda_recipe_manager/parser/types.py
+++ b/conda_recipe_manager/parser/types.py
@@ -112,6 +112,17 @@ OPPOSITE_OPS: Final[list[tuple[str, str]]] = [
 PYTHON_SKIP_PATTERN: Final[re.Pattern[str]] = re.compile(r"py[ \t]*([~!<>=]=|>|<)[ \t]*\d\d+")
 
 
+class NoArchType(StrEnum):
+    """
+    Enumerates recognized `/build/noarch` values.
+    """
+
+    # `/build/noarch` is unspecified/unrecognized.
+    NONE = ""
+    GENERIC = "generic"
+    PYTHON = "python"
+
+
 class MultilineVariant(StrEnum):
     """
     Captures which "multiline" descriptor was used on a Node, if one was used at all.

--- a/conda_recipe_manager/parser/variants_manager.py
+++ b/conda_recipe_manager/parser/variants_manager.py
@@ -4,15 +4,15 @@
 
 from __future__ import annotations
 
+import json
 from typing import Final, cast
 
 from conda_recipe_manager.parser.build_context import BuildContext
 from conda_recipe_manager.parser.cbc_reader import CbcReader
-from conda_recipe_manager.parser.recipe_parser_deps import RecipeParserDeps
 from conda_recipe_manager.parser.recipe_reader_deps import RecipeReaderDeps
 from conda_recipe_manager.parser.recipe_variant import RecipeVariant
-from conda_recipe_manager.parser.types import GeneratedVariantsType, RecipeReaderFlags
-from conda_recipe_manager.types import PRIMITIVES_TUPLE
+from conda_recipe_manager.parser.types import GeneratedVariantsType, NoArchType, RecipeReaderFlags
+from conda_recipe_manager.types import PRIMITIVES_TUPLE, Primitives
 
 
 class VariantsManager:
@@ -38,37 +38,76 @@ class VariantsManager:
         self._build_context = build_context
         self._cbc_parsers: list[CbcReader] = [CbcReader(cbc_str) for cbc_str in cbc_strs]
         variants: Final[GeneratedVariantsType] = CbcReader.generate_variants(self._cbc_parsers, build_context)
-        self._base_recipe: RecipeParserDeps = RecipeParserDeps(recipe_str, flags=flags)
+        self._base_recipe: RecipeReaderDeps = RecipeReaderDeps(recipe_str, flags=flags)
         self._recipe_variants: list[RecipeVariant] = []
-        known_hashes: set[str] = set()
+        # Tracks the structure of the recipe variant AND variable usage. Selector evaluations can cause changes that may
+        # be opaque when comparing variable usage exclusively. Conversely, identically-structured recipes may vary
+        # if they use variables with multiple defined values.
+        known_used_vars_by_hash: dict[str, set[str]] = {}
         for full_var in variants:
-            var = {key: value for key, value in full_var.items() if isinstance(value, PRIMITIVES_TUPLE)}
+            variant = {key: value for key, value in full_var.items() if isinstance(value, PRIMITIVES_TUPLE)}
             post_cbc_build_context: BuildContext = BuildContext(
-                build_context.get_platform(), {**build_context.get_context(), **var}
+                build_context.get_platform(), {**build_context.get_context(), **variant}
             )
-            recipe_var = RecipeVariant(recipe_str, post_cbc_build_context, flags=flags)
-            if recipe_var.get_value("/build/skip", default=None) is True:
+            recipe_variant = RecipeVariant(recipe_str, post_cbc_build_context, flags=flags)
+            if recipe_variant.get_value("/build/skip", default=None, sub_vars=True) is True:
                 continue
-            recipe_var_hash: str = recipe_var.calc_sha256()
-            if recipe_var_hash in known_hashes:
-                continue
-            known_hashes.add(recipe_var_hash)
-            self._recipe_variants.append(recipe_var)
 
-    def get_base_recipe(self) -> RecipeParserDeps:
+            # De-duplicate identical variations while also mimicking conda-build's behavior around `python` versions.
+            # We do this by checking variable usage within rendered variations.
+            # NOTE:
+            # - Selectors should be fully evaluated by the `RecipeVariant` class at construction, so we don't need to
+            #   worry about CBC variables used in selectors. BUT we DO have to worry about selectors changing the
+            #   structure of the variants.
+            # - We have to assume that variable usage changes with selector evaluations, so we can't save compute by
+            #   "caching" the variable values seen in the unrendered recipe file.
+            recipe_variant_vars = recipe_variant.list_variables()
+            # The `python` variable found commonly in CBC files is treated differently. Recipe files rarely, if ever,
+            # reference `python` as a selector or variable. Yet the expected behavior in `conda-build` is to generate
+            # 1-variant-per-python version.
+            # TODO Future: Figure out if there are other common CBC variables that work this way.
+            python_version = None if not recipe_variant.is_python_recipe() else variant.get("python", None)
+            used_vars: dict[str, Primitives] = {
+                var: cast(Primitives, recipe_variant.get_variable(var)) for var in recipe_variant_vars if var in variant
+            }
+            if python_version is not None:
+                # `noarch` Python packages should only have 1-Python variant, so we use the same value for all `python`
+                # versions.
+                noarch_type = recipe_variant.get_noarch_type()
+                used_vars["python"] = str(noarch_type) if noarch_type == NoArchType.PYTHON else python_version
+            serialized_used_vars = json.dumps(used_vars, sort_keys=True)
+
+            recipe_variant_hash: str = recipe_variant.calc_sha256()
+            if recipe_variant_hash in known_used_vars_by_hash:
+                if serialized_used_vars in known_used_vars_by_hash[recipe_variant_hash]:
+                    continue
+            else:
+                # Allocate set on first hash
+                known_used_vars_by_hash[recipe_variant_hash] = set()
+
+            known_used_vars_by_hash[recipe_variant_hash].add(serialized_used_vars)
+            self._recipe_variants.append(recipe_variant)
+
+    def get_base_recipe(self) -> RecipeReaderDeps:
         """
-        Returns the base recipe as a RecipeParserDeps object.
+        Returns the base (unrendered) recipe instance.
+
+        :returns: The base recipe instance.
         """
         return self._base_recipe
 
-    def get_recipe_variants(self) -> list[RecipeReaderDeps]:
+    def get_recipe_variants(self) -> list[RecipeVariant]:
         """
-        Returns the recipe variants as RecipeReaderDeps objects.
+        Returns the recipe variants as a list.
+
+        :returns: The rendered recipe variants, as a list.
         """
-        return cast(list[RecipeReaderDeps], self._recipe_variants)
+        return self._recipe_variants
 
     def get_cbc_parsers(self) -> list[CbcReader]:
         """
-        Returns the CBC parsers.
+        Returns the Conda Build Config parsers.
+
+        :returns: A list of Conda Build Config (CBC) reader-instances that initialized this instance.
         """
         return self._cbc_parsers

--- a/tests/parser/test_recipe_reader.py
+++ b/tests/parser/test_recipe_reader.py
@@ -15,7 +15,7 @@ from conda_recipe_manager.parser.cbc_reader import CbcReader  # Used in some par
 from conda_recipe_manager.parser.enums import SchemaVersion
 from conda_recipe_manager.parser.exceptions import DuplicateKeyException, DuplicateKeyWarning, ParsingJinjaException
 from conda_recipe_manager.parser.recipe_reader import RecipeReader
-from conda_recipe_manager.parser.types import RecipeReaderFlags
+from conda_recipe_manager.parser.types import NoArchType, RecipeReaderFlags
 from conda_recipe_manager.types import JsonType, Primitives
 from tests.constants import SIMPLE_DESCRIPTION
 from tests.file_loading import load_file, load_recipe
@@ -1289,7 +1289,7 @@ def test_is_multi_output(file: str, expected: bool) -> None:
 
 
 @pytest.mark.parametrize(
-    "file,expected",
+    ["file", "expected"],
     [
         ("multi-output.yaml", False),
         ("simple-recipe.yaml", False),
@@ -1312,10 +1312,31 @@ def test_is_python_recipe(file: str, expected: bool) -> None:
     """
     Validates if a recipe is a "pure Python" package.
 
-    :param file: File to test against
-    :param expected: Expected output
+    :param file: File to test against.
+    :param expected: Expected output.
     """
     assert load_recipe(file, RecipeReader).is_python_recipe() == expected
+
+
+@pytest.mark.parametrize(
+    ["file", "expected"],
+    [
+        ("multi-output.yaml", NoArchType.NONE),
+        ("types-toml.yaml", NoArchType.NONE),
+        ("boto.yaml", NoArchType.NONE),
+        ("cctools-ld64.yaml", NoArchType.NONE),
+        ("more-itertools.yaml", NoArchType.PYTHON),
+        ("gsm-amzn2-aarch64.yaml", NoArchType.GENERIC),
+    ],
+)
+def test_get_noarch_type(file: str, expected: NoArchType) -> None:
+    """
+    Validates what kind of "noarch" recipe the recipe is.
+
+    :param file: File to test against.
+    :param expected: Expected output.
+    """
+    assert load_recipe(file, RecipeReader).get_noarch_type() == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/parser/test_variants_manager.py
+++ b/tests/parser/test_variants_manager.py
@@ -26,6 +26,10 @@ from tests.file_loading import get_test_path, load_file
 @pytest.mark.parametrize(
     "feedstock",
     [
+        # Validates a simple "pure python" recipe.
+        "types-toml",
+        # Validates python-variations behavior on a simple noarch recipe file.
+        "types-toml_noarch",
         "curl",
         # NOTE: The recipe was modified to avoid a duplicate script key in each output.
         "intel_repack",
@@ -39,9 +43,10 @@ from tests.file_loading import get_test_path, load_file
         #   - To avoid duplicate build/string keys in the recipe.
         #   - To avoid duplicate summary keys in the recipe.
         "openblas",
+        # TODO Add V1 support (test cases)
     ],
 )
-def test_variants_manager(platform: Platform, feedstock: str) -> None:
+def test_variants_manager_get_recipe_variants(platform: Platform, feedstock: str) -> None:
     """
     Tests the VariantsManager class by computing recipe variants for a given feedstock and platform.
     These variants are compared against the expected variants,
@@ -57,13 +62,18 @@ def test_variants_manager(platform: Platform, feedstock: str) -> None:
     recipe_cbc_path = get_test_path() / "recipe_variants" / feedstock / "recipe" / "conda_build_config.yaml"
     recipe_path = get_test_path() / "recipe_variants" / feedstock / "recipe" / "meta.yaml"
 
-    cbc_strs: Final[list[str]] = [aggregate_cbc_path.read_text()]
+    cbc_strs: Final = [aggregate_cbc_path.read_text()]
     if recipe_cbc_path.exists():
         cbc_strs.append(recipe_cbc_path.read_text())
 
-    manager = VariantsManager(
+    manager: Final = VariantsManager(
         recipe_str=recipe_path.read_text(), cbc_strs=cbc_strs, build_context=BuildContext(platform=platform)
     )
 
-    for i, variant in enumerate(manager.get_recipe_variants()):
+    variants: Final = manager.get_recipe_variants()
+    # Ensure that the number of test files matches the number of variants produced. Otherwise, we could pass this test
+    # while producing too few variants.
+    platform_test_files: Final = list((get_test_path() / "recipe_variants" / feedstock).glob(f"{platform}_*.yaml"))
+    assert len(variants) == len(platform_test_files)
+    for i, variant in enumerate(variants):
         assert variant.render() == load_file(f"recipe_variants/{feedstock}/{platform}_{i}.yaml")

--- a/tests/test_aux_files/recipe_variants/conda_build_config.yaml
+++ b/tests/test_aux_files/recipe_variants/conda_build_config.yaml
@@ -95,7 +95,7 @@ python:
   - "3.11"
   - "3.12"
   - "3.13"
-  - "3.14"                 # [ANACONDA_ROCKET_ENABLE_PY314]
+  - "3.14"
 # numpy will by default use a compatible ABI for the oldest still-supported numpy versions
 # `{{ pin_compatible("numpy") }}` is no longer needed as builds of numpy from version 2 have run_exports.
 numpy:
@@ -107,8 +107,8 @@ numpy:
   - 2.1
   # python 3.13
   - 2.1
-  # python 3.14            # [ANACONDA_ROCKET_ENABLE_PY314]
-  - 2.3                    # [ANACONDA_ROCKET_ENABLE_PY314]
+  # python 3.14
+  - 2.3
 zip_keys:
   -
     - python

--- a/tests/test_aux_files/recipe_variants/types-toml/linux-64_0.yaml
+++ b/tests/test_aux_files/recipe_variants/types-toml/linux-64_0.yaml
@@ -1,0 +1,47 @@
+package:
+  name: types-toml
+  version: "0.10.8.6"
+
+source:
+  url: https://pypi.io/packages/source/t/types-toml/types-toml-0.10.8.6.tar.gz
+  sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - setuptools
+    - wheel
+    - pip
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - types
+  requires:
+    - pip
+  commands:
+    - pip check
+    - test -f $SP_DIR/toml-stubs/__init__.pyi
+
+about:
+  home: https://github.com/python/typeshed
+  summary: Typing stubs for toml
+  description: |
+    This is a PEP 561 type stub package for the toml package.
+    It can be used by type-checking tools like mypy, pyright,
+    pytype, PyCharm, etc. to check code that uses toml.
+  license: Apache-2.0 AND MIT
+  license_file: LICENSE
+  license_family: OTHER
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://pypi.org/project/types-toml/
+
+extra:
+  recipe-maintainers:
+    - fhoehle
+    - conda-forge/mypy

--- a/tests/test_aux_files/recipe_variants/types-toml/linux-64_1.yaml
+++ b/tests/test_aux_files/recipe_variants/types-toml/linux-64_1.yaml
@@ -1,0 +1,47 @@
+package:
+  name: types-toml
+  version: "0.10.8.6"
+
+source:
+  url: https://pypi.io/packages/source/t/types-toml/types-toml-0.10.8.6.tar.gz
+  sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - setuptools
+    - wheel
+    - pip
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - types
+  requires:
+    - pip
+  commands:
+    - pip check
+    - test -f $SP_DIR/toml-stubs/__init__.pyi
+
+about:
+  home: https://github.com/python/typeshed
+  summary: Typing stubs for toml
+  description: |
+    This is a PEP 561 type stub package for the toml package.
+    It can be used by type-checking tools like mypy, pyright,
+    pytype, PyCharm, etc. to check code that uses toml.
+  license: Apache-2.0 AND MIT
+  license_file: LICENSE
+  license_family: OTHER
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://pypi.org/project/types-toml/
+
+extra:
+  recipe-maintainers:
+    - fhoehle
+    - conda-forge/mypy

--- a/tests/test_aux_files/recipe_variants/types-toml/linux-64_2.yaml
+++ b/tests/test_aux_files/recipe_variants/types-toml/linux-64_2.yaml
@@ -1,0 +1,47 @@
+package:
+  name: types-toml
+  version: "0.10.8.6"
+
+source:
+  url: https://pypi.io/packages/source/t/types-toml/types-toml-0.10.8.6.tar.gz
+  sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - setuptools
+    - wheel
+    - pip
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - types
+  requires:
+    - pip
+  commands:
+    - pip check
+    - test -f $SP_DIR/toml-stubs/__init__.pyi
+
+about:
+  home: https://github.com/python/typeshed
+  summary: Typing stubs for toml
+  description: |
+    This is a PEP 561 type stub package for the toml package.
+    It can be used by type-checking tools like mypy, pyright,
+    pytype, PyCharm, etc. to check code that uses toml.
+  license: Apache-2.0 AND MIT
+  license_file: LICENSE
+  license_family: OTHER
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://pypi.org/project/types-toml/
+
+extra:
+  recipe-maintainers:
+    - fhoehle
+    - conda-forge/mypy

--- a/tests/test_aux_files/recipe_variants/types-toml/linux-64_3.yaml
+++ b/tests/test_aux_files/recipe_variants/types-toml/linux-64_3.yaml
@@ -1,0 +1,47 @@
+package:
+  name: types-toml
+  version: "0.10.8.6"
+
+source:
+  url: https://pypi.io/packages/source/t/types-toml/types-toml-0.10.8.6.tar.gz
+  sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - setuptools
+    - wheel
+    - pip
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - types
+  requires:
+    - pip
+  commands:
+    - pip check
+    - test -f $SP_DIR/toml-stubs/__init__.pyi
+
+about:
+  home: https://github.com/python/typeshed
+  summary: Typing stubs for toml
+  description: |
+    This is a PEP 561 type stub package for the toml package.
+    It can be used by type-checking tools like mypy, pyright,
+    pytype, PyCharm, etc. to check code that uses toml.
+  license: Apache-2.0 AND MIT
+  license_file: LICENSE
+  license_family: OTHER
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://pypi.org/project/types-toml/
+
+extra:
+  recipe-maintainers:
+    - fhoehle
+    - conda-forge/mypy

--- a/tests/test_aux_files/recipe_variants/types-toml/linux-64_4.yaml
+++ b/tests/test_aux_files/recipe_variants/types-toml/linux-64_4.yaml
@@ -1,0 +1,47 @@
+package:
+  name: types-toml
+  version: "0.10.8.6"
+
+source:
+  url: https://pypi.io/packages/source/t/types-toml/types-toml-0.10.8.6.tar.gz
+  sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - setuptools
+    - wheel
+    - pip
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - types
+  requires:
+    - pip
+  commands:
+    - pip check
+    - test -f $SP_DIR/toml-stubs/__init__.pyi
+
+about:
+  home: https://github.com/python/typeshed
+  summary: Typing stubs for toml
+  description: |
+    This is a PEP 561 type stub package for the toml package.
+    It can be used by type-checking tools like mypy, pyright,
+    pytype, PyCharm, etc. to check code that uses toml.
+  license: Apache-2.0 AND MIT
+  license_file: LICENSE
+  license_family: OTHER
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://pypi.org/project/types-toml/
+
+extra:
+  recipe-maintainers:
+    - fhoehle
+    - conda-forge/mypy

--- a/tests/test_aux_files/recipe_variants/types-toml/linux-aarch64_0.yaml
+++ b/tests/test_aux_files/recipe_variants/types-toml/linux-aarch64_0.yaml
@@ -1,0 +1,47 @@
+package:
+  name: types-toml
+  version: "0.10.8.6"
+
+source:
+  url: https://pypi.io/packages/source/t/types-toml/types-toml-0.10.8.6.tar.gz
+  sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - setuptools
+    - wheel
+    - pip
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - types
+  requires:
+    - pip
+  commands:
+    - pip check
+    - test -f $SP_DIR/toml-stubs/__init__.pyi
+
+about:
+  home: https://github.com/python/typeshed
+  summary: Typing stubs for toml
+  description: |
+    This is a PEP 561 type stub package for the toml package.
+    It can be used by type-checking tools like mypy, pyright,
+    pytype, PyCharm, etc. to check code that uses toml.
+  license: Apache-2.0 AND MIT
+  license_file: LICENSE
+  license_family: OTHER
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://pypi.org/project/types-toml/
+
+extra:
+  recipe-maintainers:
+    - fhoehle
+    - conda-forge/mypy

--- a/tests/test_aux_files/recipe_variants/types-toml/linux-aarch64_1.yaml
+++ b/tests/test_aux_files/recipe_variants/types-toml/linux-aarch64_1.yaml
@@ -1,0 +1,47 @@
+package:
+  name: types-toml
+  version: "0.10.8.6"
+
+source:
+  url: https://pypi.io/packages/source/t/types-toml/types-toml-0.10.8.6.tar.gz
+  sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - setuptools
+    - wheel
+    - pip
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - types
+  requires:
+    - pip
+  commands:
+    - pip check
+    - test -f $SP_DIR/toml-stubs/__init__.pyi
+
+about:
+  home: https://github.com/python/typeshed
+  summary: Typing stubs for toml
+  description: |
+    This is a PEP 561 type stub package for the toml package.
+    It can be used by type-checking tools like mypy, pyright,
+    pytype, PyCharm, etc. to check code that uses toml.
+  license: Apache-2.0 AND MIT
+  license_file: LICENSE
+  license_family: OTHER
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://pypi.org/project/types-toml/
+
+extra:
+  recipe-maintainers:
+    - fhoehle
+    - conda-forge/mypy

--- a/tests/test_aux_files/recipe_variants/types-toml/linux-aarch64_2.yaml
+++ b/tests/test_aux_files/recipe_variants/types-toml/linux-aarch64_2.yaml
@@ -1,0 +1,47 @@
+package:
+  name: types-toml
+  version: "0.10.8.6"
+
+source:
+  url: https://pypi.io/packages/source/t/types-toml/types-toml-0.10.8.6.tar.gz
+  sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - setuptools
+    - wheel
+    - pip
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - types
+  requires:
+    - pip
+  commands:
+    - pip check
+    - test -f $SP_DIR/toml-stubs/__init__.pyi
+
+about:
+  home: https://github.com/python/typeshed
+  summary: Typing stubs for toml
+  description: |
+    This is a PEP 561 type stub package for the toml package.
+    It can be used by type-checking tools like mypy, pyright,
+    pytype, PyCharm, etc. to check code that uses toml.
+  license: Apache-2.0 AND MIT
+  license_file: LICENSE
+  license_family: OTHER
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://pypi.org/project/types-toml/
+
+extra:
+  recipe-maintainers:
+    - fhoehle
+    - conda-forge/mypy

--- a/tests/test_aux_files/recipe_variants/types-toml/linux-aarch64_3.yaml
+++ b/tests/test_aux_files/recipe_variants/types-toml/linux-aarch64_3.yaml
@@ -1,0 +1,47 @@
+package:
+  name: types-toml
+  version: "0.10.8.6"
+
+source:
+  url: https://pypi.io/packages/source/t/types-toml/types-toml-0.10.8.6.tar.gz
+  sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - setuptools
+    - wheel
+    - pip
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - types
+  requires:
+    - pip
+  commands:
+    - pip check
+    - test -f $SP_DIR/toml-stubs/__init__.pyi
+
+about:
+  home: https://github.com/python/typeshed
+  summary: Typing stubs for toml
+  description: |
+    This is a PEP 561 type stub package for the toml package.
+    It can be used by type-checking tools like mypy, pyright,
+    pytype, PyCharm, etc. to check code that uses toml.
+  license: Apache-2.0 AND MIT
+  license_file: LICENSE
+  license_family: OTHER
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://pypi.org/project/types-toml/
+
+extra:
+  recipe-maintainers:
+    - fhoehle
+    - conda-forge/mypy

--- a/tests/test_aux_files/recipe_variants/types-toml/linux-aarch64_4.yaml
+++ b/tests/test_aux_files/recipe_variants/types-toml/linux-aarch64_4.yaml
@@ -1,0 +1,47 @@
+package:
+  name: types-toml
+  version: "0.10.8.6"
+
+source:
+  url: https://pypi.io/packages/source/t/types-toml/types-toml-0.10.8.6.tar.gz
+  sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - setuptools
+    - wheel
+    - pip
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - types
+  requires:
+    - pip
+  commands:
+    - pip check
+    - test -f $SP_DIR/toml-stubs/__init__.pyi
+
+about:
+  home: https://github.com/python/typeshed
+  summary: Typing stubs for toml
+  description: |
+    This is a PEP 561 type stub package for the toml package.
+    It can be used by type-checking tools like mypy, pyright,
+    pytype, PyCharm, etc. to check code that uses toml.
+  license: Apache-2.0 AND MIT
+  license_file: LICENSE
+  license_family: OTHER
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://pypi.org/project/types-toml/
+
+extra:
+  recipe-maintainers:
+    - fhoehle
+    - conda-forge/mypy

--- a/tests/test_aux_files/recipe_variants/types-toml/osx-arm64_0.yaml
+++ b/tests/test_aux_files/recipe_variants/types-toml/osx-arm64_0.yaml
@@ -1,0 +1,47 @@
+package:
+  name: types-toml
+  version: "0.10.8.6"
+
+source:
+  url: https://pypi.io/packages/source/t/types-toml/types-toml-0.10.8.6.tar.gz
+  sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - setuptools
+    - wheel
+    - pip
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - types
+  requires:
+    - pip
+  commands:
+    - pip check
+    - test -f $SP_DIR/toml-stubs/__init__.pyi
+
+about:
+  home: https://github.com/python/typeshed
+  summary: Typing stubs for toml
+  description: |
+    This is a PEP 561 type stub package for the toml package.
+    It can be used by type-checking tools like mypy, pyright,
+    pytype, PyCharm, etc. to check code that uses toml.
+  license: Apache-2.0 AND MIT
+  license_file: LICENSE
+  license_family: OTHER
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://pypi.org/project/types-toml/
+
+extra:
+  recipe-maintainers:
+    - fhoehle
+    - conda-forge/mypy

--- a/tests/test_aux_files/recipe_variants/types-toml/osx-arm64_1.yaml
+++ b/tests/test_aux_files/recipe_variants/types-toml/osx-arm64_1.yaml
@@ -1,0 +1,47 @@
+package:
+  name: types-toml
+  version: "0.10.8.6"
+
+source:
+  url: https://pypi.io/packages/source/t/types-toml/types-toml-0.10.8.6.tar.gz
+  sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - setuptools
+    - wheel
+    - pip
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - types
+  requires:
+    - pip
+  commands:
+    - pip check
+    - test -f $SP_DIR/toml-stubs/__init__.pyi
+
+about:
+  home: https://github.com/python/typeshed
+  summary: Typing stubs for toml
+  description: |
+    This is a PEP 561 type stub package for the toml package.
+    It can be used by type-checking tools like mypy, pyright,
+    pytype, PyCharm, etc. to check code that uses toml.
+  license: Apache-2.0 AND MIT
+  license_file: LICENSE
+  license_family: OTHER
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://pypi.org/project/types-toml/
+
+extra:
+  recipe-maintainers:
+    - fhoehle
+    - conda-forge/mypy

--- a/tests/test_aux_files/recipe_variants/types-toml/osx-arm64_2.yaml
+++ b/tests/test_aux_files/recipe_variants/types-toml/osx-arm64_2.yaml
@@ -1,0 +1,47 @@
+package:
+  name: types-toml
+  version: "0.10.8.6"
+
+source:
+  url: https://pypi.io/packages/source/t/types-toml/types-toml-0.10.8.6.tar.gz
+  sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - setuptools
+    - wheel
+    - pip
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - types
+  requires:
+    - pip
+  commands:
+    - pip check
+    - test -f $SP_DIR/toml-stubs/__init__.pyi
+
+about:
+  home: https://github.com/python/typeshed
+  summary: Typing stubs for toml
+  description: |
+    This is a PEP 561 type stub package for the toml package.
+    It can be used by type-checking tools like mypy, pyright,
+    pytype, PyCharm, etc. to check code that uses toml.
+  license: Apache-2.0 AND MIT
+  license_file: LICENSE
+  license_family: OTHER
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://pypi.org/project/types-toml/
+
+extra:
+  recipe-maintainers:
+    - fhoehle
+    - conda-forge/mypy

--- a/tests/test_aux_files/recipe_variants/types-toml/osx-arm64_3.yaml
+++ b/tests/test_aux_files/recipe_variants/types-toml/osx-arm64_3.yaml
@@ -1,0 +1,47 @@
+package:
+  name: types-toml
+  version: "0.10.8.6"
+
+source:
+  url: https://pypi.io/packages/source/t/types-toml/types-toml-0.10.8.6.tar.gz
+  sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - setuptools
+    - wheel
+    - pip
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - types
+  requires:
+    - pip
+  commands:
+    - pip check
+    - test -f $SP_DIR/toml-stubs/__init__.pyi
+
+about:
+  home: https://github.com/python/typeshed
+  summary: Typing stubs for toml
+  description: |
+    This is a PEP 561 type stub package for the toml package.
+    It can be used by type-checking tools like mypy, pyright,
+    pytype, PyCharm, etc. to check code that uses toml.
+  license: Apache-2.0 AND MIT
+  license_file: LICENSE
+  license_family: OTHER
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://pypi.org/project/types-toml/
+
+extra:
+  recipe-maintainers:
+    - fhoehle
+    - conda-forge/mypy

--- a/tests/test_aux_files/recipe_variants/types-toml/osx-arm64_4.yaml
+++ b/tests/test_aux_files/recipe_variants/types-toml/osx-arm64_4.yaml
@@ -1,0 +1,47 @@
+package:
+  name: types-toml
+  version: "0.10.8.6"
+
+source:
+  url: https://pypi.io/packages/source/t/types-toml/types-toml-0.10.8.6.tar.gz
+  sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - setuptools
+    - wheel
+    - pip
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - types
+  requires:
+    - pip
+  commands:
+    - pip check
+    - test -f $SP_DIR/toml-stubs/__init__.pyi
+
+about:
+  home: https://github.com/python/typeshed
+  summary: Typing stubs for toml
+  description: |
+    This is a PEP 561 type stub package for the toml package.
+    It can be used by type-checking tools like mypy, pyright,
+    pytype, PyCharm, etc. to check code that uses toml.
+  license: Apache-2.0 AND MIT
+  license_file: LICENSE
+  license_family: OTHER
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://pypi.org/project/types-toml/
+
+extra:
+  recipe-maintainers:
+    - fhoehle
+    - conda-forge/mypy

--- a/tests/test_aux_files/recipe_variants/types-toml/recipe/meta.yaml
+++ b/tests/test_aux_files/recipe_variants/types-toml/recipe/meta.yaml
@@ -1,0 +1,51 @@
+{% set name = "types-toml" %}
+{% set version = "0.10.8.6" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/types-toml-{{ version }}.tar.gz
+  sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
+
+build:
+  number: 0
+  skip: true  # [py<37]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - setuptools
+    - wheel
+    - pip
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - types
+  requires:
+    - pip
+  commands:
+    - pip check
+    - test -f $SP_DIR/toml-stubs/__init__.pyi  # [unix]
+
+about:
+  home: https://github.com/python/typeshed
+  summary: Typing stubs for toml
+  description: |
+    This is a PEP 561 type stub package for the toml package.
+    It can be used by type-checking tools like mypy, pyright,
+    pytype, PyCharm, etc. to check code that uses toml.
+  license: Apache-2.0 AND MIT
+  license_file: LICENSE
+  license_family: OTHER
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://pypi.org/project/types-toml/
+
+extra:
+  recipe-maintainers:
+    - fhoehle
+    - conda-forge/mypy

--- a/tests/test_aux_files/recipe_variants/types-toml/win-64_0.yaml
+++ b/tests/test_aux_files/recipe_variants/types-toml/win-64_0.yaml
@@ -1,0 +1,46 @@
+package:
+  name: types-toml
+  version: "0.10.8.6"
+
+source:
+  url: https://pypi.io/packages/source/t/types-toml/types-toml-0.10.8.6.tar.gz
+  sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - setuptools
+    - wheel
+    - pip
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - types
+  requires:
+    - pip
+  commands:
+    - pip check
+
+about:
+  home: https://github.com/python/typeshed
+  summary: Typing stubs for toml
+  description: |
+    This is a PEP 561 type stub package for the toml package.
+    It can be used by type-checking tools like mypy, pyright,
+    pytype, PyCharm, etc. to check code that uses toml.
+  license: Apache-2.0 AND MIT
+  license_file: LICENSE
+  license_family: OTHER
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://pypi.org/project/types-toml/
+
+extra:
+  recipe-maintainers:
+    - fhoehle
+    - conda-forge/mypy

--- a/tests/test_aux_files/recipe_variants/types-toml/win-64_1.yaml
+++ b/tests/test_aux_files/recipe_variants/types-toml/win-64_1.yaml
@@ -1,0 +1,46 @@
+package:
+  name: types-toml
+  version: "0.10.8.6"
+
+source:
+  url: https://pypi.io/packages/source/t/types-toml/types-toml-0.10.8.6.tar.gz
+  sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - setuptools
+    - wheel
+    - pip
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - types
+  requires:
+    - pip
+  commands:
+    - pip check
+
+about:
+  home: https://github.com/python/typeshed
+  summary: Typing stubs for toml
+  description: |
+    This is a PEP 561 type stub package for the toml package.
+    It can be used by type-checking tools like mypy, pyright,
+    pytype, PyCharm, etc. to check code that uses toml.
+  license: Apache-2.0 AND MIT
+  license_file: LICENSE
+  license_family: OTHER
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://pypi.org/project/types-toml/
+
+extra:
+  recipe-maintainers:
+    - fhoehle
+    - conda-forge/mypy

--- a/tests/test_aux_files/recipe_variants/types-toml/win-64_2.yaml
+++ b/tests/test_aux_files/recipe_variants/types-toml/win-64_2.yaml
@@ -1,0 +1,46 @@
+package:
+  name: types-toml
+  version: "0.10.8.6"
+
+source:
+  url: https://pypi.io/packages/source/t/types-toml/types-toml-0.10.8.6.tar.gz
+  sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - setuptools
+    - wheel
+    - pip
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - types
+  requires:
+    - pip
+  commands:
+    - pip check
+
+about:
+  home: https://github.com/python/typeshed
+  summary: Typing stubs for toml
+  description: |
+    This is a PEP 561 type stub package for the toml package.
+    It can be used by type-checking tools like mypy, pyright,
+    pytype, PyCharm, etc. to check code that uses toml.
+  license: Apache-2.0 AND MIT
+  license_file: LICENSE
+  license_family: OTHER
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://pypi.org/project/types-toml/
+
+extra:
+  recipe-maintainers:
+    - fhoehle
+    - conda-forge/mypy

--- a/tests/test_aux_files/recipe_variants/types-toml/win-64_3.yaml
+++ b/tests/test_aux_files/recipe_variants/types-toml/win-64_3.yaml
@@ -1,0 +1,46 @@
+package:
+  name: types-toml
+  version: "0.10.8.6"
+
+source:
+  url: https://pypi.io/packages/source/t/types-toml/types-toml-0.10.8.6.tar.gz
+  sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - setuptools
+    - wheel
+    - pip
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - types
+  requires:
+    - pip
+  commands:
+    - pip check
+
+about:
+  home: https://github.com/python/typeshed
+  summary: Typing stubs for toml
+  description: |
+    This is a PEP 561 type stub package for the toml package.
+    It can be used by type-checking tools like mypy, pyright,
+    pytype, PyCharm, etc. to check code that uses toml.
+  license: Apache-2.0 AND MIT
+  license_file: LICENSE
+  license_family: OTHER
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://pypi.org/project/types-toml/
+
+extra:
+  recipe-maintainers:
+    - fhoehle
+    - conda-forge/mypy

--- a/tests/test_aux_files/recipe_variants/types-toml/win-64_4.yaml
+++ b/tests/test_aux_files/recipe_variants/types-toml/win-64_4.yaml
@@ -1,0 +1,46 @@
+package:
+  name: types-toml
+  version: "0.10.8.6"
+
+source:
+  url: https://pypi.io/packages/source/t/types-toml/types-toml-0.10.8.6.tar.gz
+  sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - setuptools
+    - wheel
+    - pip
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - types
+  requires:
+    - pip
+  commands:
+    - pip check
+
+about:
+  home: https://github.com/python/typeshed
+  summary: Typing stubs for toml
+  description: |
+    This is a PEP 561 type stub package for the toml package.
+    It can be used by type-checking tools like mypy, pyright,
+    pytype, PyCharm, etc. to check code that uses toml.
+  license: Apache-2.0 AND MIT
+  license_file: LICENSE
+  license_family: OTHER
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://pypi.org/project/types-toml/
+
+extra:
+  recipe-maintainers:
+    - fhoehle
+    - conda-forge/mypy

--- a/tests/test_aux_files/recipe_variants/types-toml_noarch/linux-64_0.yaml
+++ b/tests/test_aux_files/recipe_variants/types-toml_noarch/linux-64_0.yaml
@@ -1,0 +1,48 @@
+package:
+  name: types-toml
+  version: "0.10.8.6"
+
+source:
+  url: https://pypi.io/packages/source/t/types-toml/types-toml-0.10.8.6.tar.gz
+  sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - setuptools
+    - wheel
+    - pip
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - types
+  requires:
+    - pip
+  commands:
+    - pip check
+    - test -f $SP_DIR/toml-stubs/__init__.pyi
+
+about:
+  home: https://github.com/python/typeshed
+  summary: Typing stubs for toml
+  description: |
+    This is a PEP 561 type stub package for the toml package.
+    It can be used by type-checking tools like mypy, pyright,
+    pytype, PyCharm, etc. to check code that uses toml.
+  license: Apache-2.0 AND MIT
+  license_file: LICENSE
+  license_family: OTHER
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://pypi.org/project/types-toml/
+
+extra:
+  recipe-maintainers:
+    - fhoehle
+    - conda-forge/mypy

--- a/tests/test_aux_files/recipe_variants/types-toml_noarch/linux-aarch64_0.yaml
+++ b/tests/test_aux_files/recipe_variants/types-toml_noarch/linux-aarch64_0.yaml
@@ -1,0 +1,48 @@
+package:
+  name: types-toml
+  version: "0.10.8.6"
+
+source:
+  url: https://pypi.io/packages/source/t/types-toml/types-toml-0.10.8.6.tar.gz
+  sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - setuptools
+    - wheel
+    - pip
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - types
+  requires:
+    - pip
+  commands:
+    - pip check
+    - test -f $SP_DIR/toml-stubs/__init__.pyi
+
+about:
+  home: https://github.com/python/typeshed
+  summary: Typing stubs for toml
+  description: |
+    This is a PEP 561 type stub package for the toml package.
+    It can be used by type-checking tools like mypy, pyright,
+    pytype, PyCharm, etc. to check code that uses toml.
+  license: Apache-2.0 AND MIT
+  license_file: LICENSE
+  license_family: OTHER
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://pypi.org/project/types-toml/
+
+extra:
+  recipe-maintainers:
+    - fhoehle
+    - conda-forge/mypy

--- a/tests/test_aux_files/recipe_variants/types-toml_noarch/osx-arm64_0.yaml
+++ b/tests/test_aux_files/recipe_variants/types-toml_noarch/osx-arm64_0.yaml
@@ -1,0 +1,48 @@
+package:
+  name: types-toml
+  version: "0.10.8.6"
+
+source:
+  url: https://pypi.io/packages/source/t/types-toml/types-toml-0.10.8.6.tar.gz
+  sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - setuptools
+    - wheel
+    - pip
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - types
+  requires:
+    - pip
+  commands:
+    - pip check
+    - test -f $SP_DIR/toml-stubs/__init__.pyi
+
+about:
+  home: https://github.com/python/typeshed
+  summary: Typing stubs for toml
+  description: |
+    This is a PEP 561 type stub package for the toml package.
+    It can be used by type-checking tools like mypy, pyright,
+    pytype, PyCharm, etc. to check code that uses toml.
+  license: Apache-2.0 AND MIT
+  license_file: LICENSE
+  license_family: OTHER
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://pypi.org/project/types-toml/
+
+extra:
+  recipe-maintainers:
+    - fhoehle
+    - conda-forge/mypy

--- a/tests/test_aux_files/recipe_variants/types-toml_noarch/recipe/meta.yaml
+++ b/tests/test_aux_files/recipe_variants/types-toml_noarch/recipe/meta.yaml
@@ -1,0 +1,52 @@
+{% set name = "types-toml" %}
+{% set version = "0.10.8.6" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/types-toml-{{ version }}.tar.gz
+  sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
+
+build:
+  number: 0
+  skip: true  # [py<37]
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - setuptools
+    - wheel
+    - pip
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - types
+  requires:
+    - pip
+  commands:
+    - pip check
+    - test -f $SP_DIR/toml-stubs/__init__.pyi  # [unix]
+
+about:
+  home: https://github.com/python/typeshed
+  summary: Typing stubs for toml
+  description: |
+    This is a PEP 561 type stub package for the toml package.
+    It can be used by type-checking tools like mypy, pyright,
+    pytype, PyCharm, etc. to check code that uses toml.
+  license: Apache-2.0 AND MIT
+  license_file: LICENSE
+  license_family: OTHER
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://pypi.org/project/types-toml/
+
+extra:
+  recipe-maintainers:
+    - fhoehle
+    - conda-forge/mypy

--- a/tests/test_aux_files/recipe_variants/types-toml_noarch/win-64_0.yaml
+++ b/tests/test_aux_files/recipe_variants/types-toml_noarch/win-64_0.yaml
@@ -1,0 +1,47 @@
+package:
+  name: types-toml
+  version: "0.10.8.6"
+
+source:
+  url: https://pypi.io/packages/source/t/types-toml/types-toml-0.10.8.6.tar.gz
+  sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - setuptools
+    - wheel
+    - pip
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - types
+  requires:
+    - pip
+  commands:
+    - pip check
+
+about:
+  home: https://github.com/python/typeshed
+  summary: Typing stubs for toml
+  description: |
+    This is a PEP 561 type stub package for the toml package.
+    It can be used by type-checking tools like mypy, pyright,
+    pytype, PyCharm, etc. to check code that uses toml.
+  license: Apache-2.0 AND MIT
+  license_file: LICENSE
+  license_family: OTHER
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://pypi.org/project/types-toml/
+
+extra:
+  recipe-maintainers:
+    - fhoehle
+    - conda-forge/mypy


### PR DESCRIPTION
- Aligns `VariantsManager` logic to more closely match the current behavior of `conda-build` when it comes to "pure python" packages and `noarch` support.
- Fixes some typing inconsistencies in `VariantsManager`
- Adds a new `NoArchType` enumeration and a convenience `RecipeReader::get_noarch_type()` function
- Adds and improves tests...apologies to the reviewer by the sheer number of new test files that look nearly identical.