### PR TITLE
Avoid duplicate blank lines after multiline sections

### DIFF
--- a/conda_recipe_manager/parser/recipe_reader.py
+++ b/conda_recipe_manager/parser/recipe_reader.py
@@ -1160,7 +1160,9 @@ class RecipeReader(IsModifiable):
             is_last_line = depth < 0 and child == node.children[-1]
             if is_last_line and omit_trailing_newline:
                 return
-            if (is_cbc and is_last_line) or (not is_cbc and depth < 0 and not child.is_comment()):
+            if (is_cbc and is_last_line) or (
+                not is_cbc and depth < 0 and not child.is_comment() and (not lines or lines[-1] != "")
+            ):
                 lines.append("")
 
     def render(self, omit_trailing_newline: bool = False) -> str:

--- a/tests/parser/test_recipe_reader.py
+++ b/tests/parser/test_recipe_reader.py
@@ -139,6 +139,25 @@ def test_str(file: str, out_file: str) -> None:
     assert not parser.is_modified()
 
 
+def test_round_trip_multiline_string_before_next_section() -> None:
+    """
+    Validates that a section separator after a multi-line string does not get captured as part of the string.
+    """
+    content: Final[str] = (
+        "about:\n"
+        "  summary: Example output 2\n"
+        "  description: |\n"
+        "    This is a test package for output2.\n"
+        "\n"
+        "extra:\n"
+        "  recipe-maintainers:\n"
+        "    - conda\n"
+    )
+    parser: Final = RecipeReader(content)
+
+    assert parser.render() == content
+
+
 @pytest.mark.parametrize(
     "file,other_file",
     [

--- a/tests/test_aux_files/selector_filtering/gluonts_linux_aarch_64.yaml
+++ b/tests/test_aux_files/selector_filtering/gluonts_linux_aarch_64.yaml
@@ -116,7 +116,6 @@ about:
     GluonTS is a Python package for probabilistic time series modeling, focusing on deep learning based models, based
     on PyTorch and MXNet.
 
-
 extra:
   recipe-maintainers:
     - dkomisar


### PR DESCRIPTION
## Summary
- avoid adding an extra top-level separator when the previous rendered line is already blank
- add a regression for a multiline string followed by the next top-level section
- update the selector-filtering expected output to keep one section separator

Closes #527.

## Validation
- `conda env create -p ./.conda-test -f environment.yaml`
- `pytest tests/parser/test_recipe_reader.py tests/parser/test_recipe_variant.py -q`
- `pytest tests/parser -q`
- `git diff --check`