### PR TITLE
Fix duplicate blank lines after multiline sections

### DIFF
--- a/conda_recipe_manager/parser/recipe_reader.py
+++ b/conda_recipe_manager/parser/recipe_reader.py
@@ -1160,7 +1160,10 @@ class RecipeReader(IsModifiable):
             is_last_line = depth < 0 and child == node.children[-1]
             if is_last_line and omit_trailing_newline:
                 return
-            if (is_cbc and is_last_line) or (not is_cbc and depth < 0 and not child.is_comment()):
+            if (
+                (is_cbc and is_last_line)
+                or (not is_cbc and depth < 0 and not child.is_comment())
+            ) and (not lines or lines[-1] != ""):
                 lines.append("")
 
     def render(self, omit_trailing_newline: bool = False) -> str:

--- a/tests/parser/test_recipe_reader.py
+++ b/tests/parser/test_recipe_reader.py
@@ -174,6 +174,26 @@ def test_loading_obj_in_list() -> None:
     assert parser.render() == replace
 
 
+def test_multiline_string_before_top_level_section_does_not_duplicate_blank_line() -> None:
+    """
+    Regression test for multiline strings at the end of top-level sections.
+    """
+    content = (
+        "about:\n"
+        "  summary: Example output 2\n"
+        "  description: |\n"
+        "    This is a test package for output2.\n"
+        "\n"
+        "extra:\n"
+        "  recipe-maintainers:\n"
+        "    - conda\n"
+    )
+
+    parser = RecipeReader(content)
+
+    assert parser.render() == content
+
+
 @pytest.mark.parametrize(
     ["file", "cls"],
     [


### PR DESCRIPTION
## Summary
- avoid appending an extra top-level separator when rendering already ended on a blank line
- add a regression test for recipes where a top-level section ends with a block scalar multiline string

Fixes #527.

## Tests
- `.venv/bin/python` wrapper with a minimal `conda.models.match_spec` stub: `pytest -q tests/parser/test_recipe_reader.py` -> 383 passed
- `.venv/bin/python -m compileall -q conda_recipe_manager/parser/recipe_reader.py tests/parser/test_recipe_reader.py`
- `git diff --check`

Note: I used a local stub for `conda.models.match_spec` because the project depends on the `conda` package from conda-forge, which is not installable from PyPI. The touched tests do not exercise dependency parsing.