### PR TITLE
Recover when a list-leaf is rendered into a dict context

### DIFF
--- a/conda_recipe_manager/parser/recipe_reader.py
+++ b/conda_recipe_manager/parser/recipe_reader.py
@@ -1218,8 +1218,31 @@ class RecipeReader(IsModifiable):
             return
 
         if node.is_strong_leaf():
-            # At this point, we know the data is a list
-            data.append(self._preprocess_node_value(node, replace_variables))
+            value = self._preprocess_node_value(node, replace_variables)
+            # The common case: a strong leaf appears as a list member, so `data` is the
+            # parent list to which we append. If the parser instead handed us a dict, the
+            # leaf was promoted to a sibling of an empty-key node — typically because of
+            # selector comments / blank lines disturbing list nesting (see
+            # https://github.com/conda/conda-recipe-manager/issues/<TBD>). Recover by
+            # attaching the leaf as a single-item list under the most recent empty-key
+            # sibling, which preserves the data the user clearly intended.
+            if isinstance(data, list):
+                data.append(value)
+            elif isinstance(data, dict) and data:
+                last_key = next(reversed(data))
+                if data[last_key] is None:
+                    data[last_key] = [value]
+                elif isinstance(data[last_key], list):
+                    data[last_key].append(value)
+                else:
+                    raise TypeError(
+                        f"List leaf {value!r} cannot be attached: previous key "
+                        f"{last_key!r} already has a non-list value."
+                    )
+            else:
+                raise TypeError(
+                    f"List leaf {value!r} appeared with no list context to append to."
+                )
             return
 
         # Process collection nodes (lists or dicts that are list members)

--- a/tests/parser/test_cbc_parser.py
+++ b/tests/parser/test_cbc_parser.py
@@ -565,3 +565,25 @@ def test_generate_variants(
         assert _find_matching_variant(exp_var, generated_variants)
     for gen_var in generated_variants:
         assert _find_matching_variant(gen_var, expected_variants)
+
+
+def test_empty_key_with_selector_followed_by_list() -> None:
+    """
+    Regression test: CBCs that pin a key only on a particular platform are sometimes
+    written as an empty key with a selector comment, immediately followed by a list
+    item also under a selector. This shape used to crash `_render_object_tree` with
+    "'dict' object has no attribute 'append'" because the parser promoted the list
+    item to a sibling of the empty key. The render layer now recovers by attaching
+    the leaf back under the most recent empty-key sibling.
+    """
+    cbc = (
+        "c_compiler:                    # [win]\n"
+        "- vs2019                       # [win]\n"
+        "cxx_compiler:                  # [win]\n"
+        "- vs2019                       # [win]\n"
+    )
+    parser = CbcParser(cbc)
+    assert parser.get_value("/") == {
+        "c_compiler": ["vs2019"],
+        "cxx_compiler": ["vs2019"],
+    }


### PR DESCRIPTION
## Summary

CBCs that pin a key only on a particular platform are sometimes written as an empty key with a selector comment, immediately followed by a list item also under a selector. For example:

```yaml
c_compiler:                    # [win]
- vs2019                       # [win]
cxx_compiler:                  # [win]
- vs2019                       # [win]
```

The parser promotes the list item (`vs2019`) to a sibling of the empty-key (`c_compiler`) instead of nesting it underneath. When `_render_object_tree` then encounters the list leaf with the root dict as its `data` argument, it crashes:

```
File ".../conda_recipe_manager/parser/recipe_reader.py", line 1254, in _render_object_tree
    data.append(self._preprocess_node_value(node, replace_variables))
AttributeError: 'dict' object has no attribute 'append'
```

The comment on the offending line (`# At this point, we know the data is a list`) makes the assumption explicit, which is exactly the assumption that breaks here.

## Fix

Recover at the render layer: when a strong-leaf node arrives with a dict parent, attach it back under the most recent empty-key sibling — the only intent that makes sense for this YAML shape.

The deeper fix is at the parser level (don't let the empty-key's children get reparented when both have selector comments), but that's a much larger change with broader risk. This unblocks downstream consumers without changing the success path. Happy to take a different direction if the maintainers prefer the deeper fix.

## Test plan

- [x] Added a regression test in `tests/parser/test_cbc_parser.py` with a 4-line repro
- [x] Confirmed the new test passes
- [x] All 722 tests in `tests/parser/` pass with the change

## Discovery context

Found while debugging a PBP linter failure on [AnacondaRecipes/tesseract-feedstock#6](https://github.com/AnacondaRecipes/tesseract-feedstock/pull/6). The crash blocks anaconda-linter against any feedstock whose `recipe/conda_build_config.yaml` happens to take this YAML shape — the original tesseract recipe had it from a 2022-era snapshot of `vs2019` Windows pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)