### PR TITLE
Fixes a bad cast and a new `black` format warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ lint:			## Runs the linter against the project
 
 format:			## Runs the code auto-formatter
 	isort --profile black --line-length=120 $(SRC_DIR) $(TEST_DIR) $(SCRIPTS_DIR)
-	black --line-length=120 $(SRC_DIR) $(TEST_DIR) $(SCRIPTS_DIR)
+	black --line-length=120 --target-version py311 $(SRC_DIR) $(TEST_DIR) $(SCRIPTS_DIR)
 
 format-docs:	## Runs the docstring auto-formatter. NOTE: this requires manually installing `docconvert` with `pip`
 	docconvert --in-place --config .docconvert.json $(SRC_DIR)

--- a/conda_recipe_manager/fetcher/artifact_fetcher.py
+++ b/conda_recipe_manager/fetcher/artifact_fetcher.py
@@ -183,9 +183,7 @@ def _fetch_archive(fetcher: BaseArtifactFetcher, retry_interval: float, retries:
             if retry_id < retries:
                 time.sleep(retry_id * retry_interval)
 
-    raise FetchError(
-        f"Failed to fetch `{fetcher}` | {cast(HttpArtifactFetcher, fetcher).get_archive_url()} after {retries} retries."
-    )
+    raise FetchError(f"Failed to fetch `{fetcher}` after {retries} retries.")
 
 
 @contextmanager


### PR DESCRIPTION
- Fixes a bad `cast` that incorrectly suppressed a legitimate `mypy` error. This caused the wrong exception to be thrown when a package failed to be acquired.
- Also fixes a newer black formatting warning