### PR TITLE
Fix detect binary files prefix inversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Note: version releases in the 0.x.y range may introduce breaking changes.
 ### Deprecated
 ### Removed
 ### Fixed
+- `crm convert` now negates `detect_binary_files_with_prefix` when converting it to the V1
+  `prefix_detection/ignore_binary_files` field. The two flags are logical inverses, so previously carrying the value
+  over unchanged produced recipes with inverted binary prefix-replacement behavior.
 ### Security
 
 ## [0.10.4]

--- a/conda_recipe_manager/parser/recipe_parser_convert.py
+++ b/conda_recipe_manager/parser/recipe_parser_convert.py
@@ -626,6 +626,17 @@ class RecipeParserConvert(RecipeParserDeps):
             # New `prefix_detection` section changes
             # NOTE: There is a new `force_file_type` field that may map to an unknown field that conda supports.
             self._patch_move_new_path(build_path, "/ignore_prefix_files", "/prefix_detection", "/ignore")
+            # V0's `detect_binary_files_with_prefix` is the logical inverse of V1's
+            # `prefix_detection/ignore_binary_files`, so the boolean value must be negated as part of the move.
+            detect_binary_path = RecipeParser.append_to_path(build_path, "/detect_binary_files_with_prefix")
+            if self._v1_recipe.contains_value(detect_binary_path):
+                self._patch_and_log(
+                    {
+                        "op": "replace",
+                        "path": detect_binary_path,
+                        "value": not self._v1_recipe.get_value(detect_binary_path),
+                    }
+                )
             self._patch_move_new_path(
                 build_path, "/detect_binary_files_with_prefix", "/prefix_detection", "/ignore_binary_files"
             )

--- a/tests/test_aux_files/dynamic-linking.yaml
+++ b/tests/test_aux_files/dynamic-linking.yaml
@@ -15,6 +15,9 @@ build:
     - "**/lib.so"
   runpath_whitelist:
     - "**/lib.so"
+  detect_binary_files_with_prefix: true
+  ignore_prefix_files:
+    - "**/text_file.txt"
 
 requirements:
   host:

--- a/tests/test_aux_files/v1_format/v1_dynamic-linking.yaml
+++ b/tests/test_aux_files/v1_format/v1_dynamic-linking.yaml
@@ -14,6 +14,10 @@ source:
 
 build:
   number: 0
+  prefix_detection:
+    ignore:
+      - "**/text_file.txt"
+    ignore_binary_files: false
   dynamic_linking:
     missing_dso_allowlist:
       - "**/lib.so"


### PR DESCRIPTION
### Description

In https://github.com/conda-forge/texlive-core-feedstock/pull/110 `conda-recipe-manager` incorrectly converted the recipe due to the boolean flag for `detect_binary_files_with_prefix` not being inverted when it was renamed to `ignore_binary_files`.

This PR adds a test and fixes it.